### PR TITLE
Including the django-stubs dependency.

### DIFF
--- a/django_tasks/__init__.py
+++ b/django_tasks/__init__.py
@@ -1,3 +1,8 @@
+# ruff: noqa: E402
+import django_stubs_ext
+
+django_stubs_ext.monkeypatch()
+
 from typing import Mapping, Optional, cast
 
 from django.core import signals

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "Django>=4.2",
-    "typing_extensions"
+    "typing_extensions",
+    "django-stubs-ext",
 ]
 
 [project.urls]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,9 +1,6 @@
 import os
 
 import dj_database_url
-import django_stubs_ext
-
-django_stubs_ext.monkeypatch()
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
Without these changes importing the package results in a TypeError:

```
  File "/Users/[...]/django-tasks-master/django_tasks/__init__.py", line 30, in <module>
    class TasksHandler(BaseConnectionHandler[BaseTaskBackend]):
                       ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
TypeError: type 'BaseConnectionHandler' is not subscriptable
```