### PR TITLE
#18 - Implemented basic django admin view for DBTaskResult

### DIFF
--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from django.contrib import admin
 from django.http import HttpRequest
@@ -18,5 +18,5 @@ class DBTaskResultAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(
         self, request: HttpRequest, obj: Optional[DBTaskResult] = None
-    ) -> list[str]:
+    ) -> List[str]:
         return [f.name for f in self.model._meta.fields]

--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -1,0 +1,15 @@
+from django.contrib import admin
+
+from .models import DBTaskResult
+
+
+@admin.register(DBTaskResult)
+class DBTaskResultAdmin(admin.ModelAdmin):
+    list_display = ("id", "task_path", "status", "priority", "queue_name")
+    list_filter = ("status", "priority", "queue_name")
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    def get_readonly_fields(self, request, obj=None):
+        return [f.name for f in self.model._meta.fields]

--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -8,7 +8,7 @@ from .models import DBTaskResult
 
 @admin.register(DBTaskResult)
 class DBTaskResultAdmin(admin.ModelAdmin):
-    list_display = ("id", "task_path", "status", "priority", "queue_name")
+    list_display = ("id", "get_task_name", "status", "priority", "queue_name")
     list_filter = ("status", "priority", "queue_name")
 
     def has_add_permission(
@@ -30,3 +30,7 @@ class DBTaskResultAdmin(admin.ModelAdmin):
         self, request: HttpRequest, obj: Optional[DBTaskResult] = None
     ) -> List[str]:
         return [f.name for f in self.model._meta.fields]
+
+    @admin.display(description="Task")
+    def get_task_name(self, obj: DBTaskResult) -> str:
+        return obj.task.name

--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -16,6 +16,16 @@ class DBTaskResultAdmin(admin.ModelAdmin):
     ) -> bool:
         return False
 
+    def has_delete_permission(
+        self, request: HttpRequest, obj: Optional[DBTaskResult] = None
+    ) -> bool:
+        return False
+
+    def has_change_permission(
+        self, request: HttpRequest, obj: Optional[DBTaskResult] = None
+    ) -> bool:
+        return False
+
     def get_readonly_fields(
         self, request: HttpRequest, obj: Optional[DBTaskResult] = None
     ) -> List[str]:

--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -1,4 +1,4 @@
-from typing import Optional, List
+from typing import List, Optional
 
 from django.contrib import admin
 from django.http import HttpRequest

--- a/django_tasks/backends/database/admin.py
+++ b/django_tasks/backends/database/admin.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from django.contrib import admin
+from django.http import HttpRequest
 
 from .models import DBTaskResult
 
@@ -8,8 +11,12 @@ class DBTaskResultAdmin(admin.ModelAdmin):
     list_display = ("id", "task_path", "status", "priority", "queue_name")
     list_filter = ("status", "priority", "queue_name")
 
-    def has_add_permission(self, request, obj=None):
+    def has_add_permission(
+        self, request: HttpRequest, obj: Optional[DBTaskResult] = None
+    ) -> bool:
         return False
 
-    def get_readonly_fields(self, request, obj=None):
+    def get_readonly_fields(
+        self, request: HttpRequest, obj: Optional[DBTaskResult] = None
+    ) -> list[str]:
         return [f.name for f in self.model._meta.fields]

--- a/django_tasks/backends/database/apps.py
+++ b/django_tasks/backends/database/apps.py
@@ -4,3 +4,4 @@ from django.apps import AppConfig
 class TasksAppConfig(AppConfig):
     name = "django_tasks.backends.database"
     label = "django_tasks_database"
+    verbose_name = "Tasks Database Backend"

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -83,6 +83,8 @@ class DBTaskResult(GenericBase[P, T], models.Model):
 
     class Meta:
         ordering = [F("priority").desc(), F("run_after").desc(nulls_last=True)]
+        verbose_name = "Task Result"
+        verbose_name_plural = "Task Results"
 
     @property
     def task(self) -> Task[P, T]:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,9 +1,13 @@
 import os
+import sys
 
 import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DEBUG = True
+
+if sys.argv[0] != "test":
+    DEBUG = True
+    TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}
 
 ALLOWED_HOSTS = ["*"]
 
@@ -41,8 +45,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
-
-TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}
 
 STATIC_URL = "/static/"
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,10 +5,6 @@ import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-if sys.argv[0] != "test":
-    DEBUG = True
-    TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}
-
 ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
@@ -61,3 +57,7 @@ DATABASES = {
 }
 
 USE_TZ = True
+
+if sys.argv[0] != "test":
+    DEBUG = True
+    TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -3,30 +3,52 @@ import os
 import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.messages",
+    "django.contrib.sessions",
+    "django.contrib.staticfiles",
     "django_tasks",
     "django_tasks.backends.database",
     "tests",
 ]
 
-# TEMPLATES = [
-#     {
-#         "BACKEND": "django.template.backends.django.DjangoTemplates",
-#         "DIRS": [],
-#         "APP_DIRS": True,
-#         "OPTIONS": {
-#             "context_processors": [
-#                 "django.template.context_processors.debug",
-#                 "django.template.context_processors.request",
-#                 "django.contrib.auth.context_processors.auth",
-#                 "django.contrib.messages.context_processors.messages",
-#             ]
-#         },
-#     },
-# ]
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+                "django.template.context_processors.static",
+            ]
+        },
+    },
+]
+
+MIDDLEWARE = [
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+]
+
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.database.DatabaseBackend"
+    }
+}
+
+STATIC_URL = "/static/"
 
 SECRET_KEY = "abcde12345"
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -42,11 +42,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
 ]
 
-TASKS = {
-    "default": {
-        "BACKEND": "django_tasks.backends.database.DatabaseBackend"
-    }
-}
+TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}
 
 STATIC_URL = "/static/"
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,4 +1,7 @@
 from django.urls import path
+from django.contrib import admin
+
+admin.autodiscover()
 
 from . import views
 
@@ -10,4 +13,5 @@ urlpatterns = [
         views.calculate_meaning_of_life_async,
         name="meaning-of-life-async",
     ),
+    path("admin/", admin.site.urls),
 ]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -3,8 +3,6 @@ from django.urls import path
 
 from . import views
 
-admin.autodiscover()
-
 urlpatterns = [
     path("meaning-of-life/", views.calculate_meaning_of_life, name="meaning-of-life"),
     path("result/<str:result_id>", views.get_task_result, name="result"),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,9 +1,9 @@
-from django.urls import path
 from django.contrib import admin
-
-admin.autodiscover()
+from django.urls import path
 
 from . import views
+
+admin.autodiscover()
 
 urlpatterns = [
     path("meaning-of-life/", views.calculate_meaning_of_life, name="meaning-of-life"),


### PR DESCRIPTION
Changes:
- Configures basic settings to include django admin (+auth, static files)
- Add basic django admin view
- Django admins are configured to be read-only

Screenshots:

<img width="1155" alt="Screenshot 2024-06-08 at 12 42 08" src="https://github.com/RealOrangeOne/django-tasks/assets/13806/303b0f92-7b0a-41bf-9a33-9a9ca8973a2b">

<img width="1479" alt="Screenshot 2024-06-08 at 12 42 16" src="https://github.com/RealOrangeOne/django-tasks/assets/13806/abc4a931-39ac-4a03-8b4d-93c5229365ed">

Ref #18 