### PR TITLE
Using the DEFAULT_TASK_BACKEND_ALIAS constant

### DIFF
--- a/django_tasks/__init__.py
+++ b/django_tasks/__init__.py
@@ -11,7 +11,13 @@ from django.utils.module_loading import import_string
 
 from .backends.base import BaseTaskBackend
 from .exceptions import InvalidTaskBackendError
-from .task import DEFAULT_QUEUE_NAME, ResultStatus, Task, task
+from .task import (
+    DEFAULT_QUEUE_NAME,
+    DEFAULT_TASK_BACKEND_ALIAS,
+    ResultStatus,
+    Task,
+    task,
+)
 
 __version__ = "0.0.0"
 
@@ -23,8 +29,6 @@ __all__ = [
     "ResultStatus",
     "Task",
 ]
-
-DEFAULT_TASK_BACKEND_ALIAS = "default"
 
 
 class TasksHandler(BaseConnectionHandler[BaseTaskBackend]):
@@ -38,7 +42,7 @@ class TasksHandler(BaseConnectionHandler[BaseTaskBackend]):
             # HACK: Force a default task backend.
             # Can be replaced with `django.conf.global_settings` once vendored.
             return {
-                "default": {
+                DEFAULT_TASK_BACKEND_ALIAS: {
                     "BACKEND": "django_tasks.backends.immediate.ImmediateBackend"
                 }
             }

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -23,6 +23,7 @@ from .exceptions import ResultDoesNotExist
 if TYPE_CHECKING:
     from .backends.base import BaseTaskBackend
 
+DEFAULT_TASK_BACKEND_ALIAS = "default"
 DEFAULT_QUEUE_NAME = "default"
 
 
@@ -151,7 +152,7 @@ class Task(Generic[P, T]):
 def task(
     priority: int = 0,
     queue_name: str = DEFAULT_QUEUE_NAME,
-    backend: str = "default",
+    backend: str = DEFAULT_TASK_BACKEND_ALIAS,
 ) -> Callable[[Callable[P, T]], Task[P, T]]:
     """
     A decorator used to create a task.


### PR DESCRIPTION
Using the `DEFAULT_TASK_BACKEND_ALIAS` constant when referencing to the default task backend instead of repeating the string.