### PR TITLE
Fix #42 Use modules in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -3,16 +3,17 @@
   just --list
 
 test *ARGS:
-    ./manage.py makemigrations --check --noinput
-    coverage run --source=django_tasks manage.py test {{ ARGS }}
-    coverage report
-    coverage html
+    python -m manage check
+    python -m manage makemigrations --dry-run --check --noinput
+    python -m coverage run --source=django_tasks -m manage test --shuffle --noinput {{ ARGS }}
+    python -m coverage report
+    python -m coverage html
 
 format:
-    ruff check django_tasks tests --fix
-    ruff format django_tasks tests
+    python -m ruff check django_tasks tests --fix
+    python -m ruff format django_tasks tests
 
 lint:
-    ruff check django_tasks tests
-    ruff format django_tasks tests --check
-    mypy django_tasks tests
+    python -m ruff check django_tasks tests
+    python -m ruff format django_tasks tests --check
+    python -m mypy django_tasks tests


### PR DESCRIPTION
Fix #42 as shown to @RealOrangeOne during the DjangoCon Europe 2024 sprints, I propose to invoke the commands in the `justfile` using their respective modules.