### PR TITLE
Adding a check that ensures the app required for the database backend…

### DIFF
--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -165,6 +165,18 @@ class DatabaseBackendTestCase(TestCase):
         ):
             _ = db_task_result.task
 
+    def test_check(self) -> None:
+        errors = default_task_backend.check()
+
+        self.assertEqual(len(errors), 0)
+
+    @override_settings(INSTALLED_APPS=[])
+    def test_database_backend_app_missing(self) -> None:
+        errors = default_task_backend.check()
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("django_tasks.backends.database", errors[0].hint)
+
 
 @override_settings(
     TASKS={


### PR DESCRIPTION
… is installed.

Although the proper setup is documented in the README, it is easy to miss and (a little) hassle to debug without knowledge of the django_tasks code itself.