### PR TITLE
Support task decorator without arguments

### DIFF
--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -174,7 +174,7 @@ def task(
     priority: int = 0,
     queue_name: str = DEFAULT_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
-) -> Task[P, T] | Callable[[Callable[P, T]], Task[P, T]]:
+) -> Union[Task[P, T], Callable[[Callable[P, T]], Task[P, T]]]:
     """
     A decorator used to create a task.
     """

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -153,7 +153,7 @@ class Task(Generic[P, T]):
 # Bare decorator usage
 # e.g. @task
 @overload
-def task(function: Callable[P, T]) -> Task[P, T]: ...
+def task(function: Callable[P, T], /) -> Task[P, T]: ...
 
 
 # Decorator with arguments

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -6,6 +6,11 @@ def noop_task(*args: tuple, **kwargs: dict) -> None:
     return None
 
 
+@task
+def noop_task_from_bare_decorator(*args: tuple, **kwargs: dict) -> None:
+    return None
+
+
 @task()
 async def noop_task_async(*args: tuple, **kwargs: dict) -> None:
     return None

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -16,11 +16,6 @@ async def noop_task_async(*args: tuple, **kwargs: dict) -> None:
     return None
 
 
-@task
-async def noop_task_async_from_bare_decorator(*args: tuple, **kwargs: dict) -> None:
-    return None
-
-
 @task()
 def calculate_meaning_of_life() -> int:
     return 42

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -16,6 +16,11 @@ async def noop_task_async(*args: tuple, **kwargs: dict) -> None:
     return None
 
 
+@task
+async def noop_task_async_from_bare_decorator(*args: tuple, **kwargs: dict) -> None:
+    return None
+
+
 @task()
 def calculate_meaning_of_life() -> int:
     return 42

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -41,6 +41,7 @@ class TaskTestCase(SimpleTestCase):
     def test_task_decorator(self) -> None:
         self.assertIsInstance(test_tasks.noop_task, Task)
         self.assertIsInstance(test_tasks.noop_task_from_bare_decorator, Task)
+        self.assertIsInstance(test_tasks.noop_task_async_from_bare_decorator, Task)
 
     def test_enqueue_task(self) -> None:
         result = test_tasks.noop_task.enqueue()

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -40,8 +40,8 @@ class TaskTestCase(SimpleTestCase):
 
     def test_task_decorator(self) -> None:
         self.assertIsInstance(test_tasks.noop_task, Task)
+        self.assertIsInstance(test_tasks.noop_task_async, Task)
         self.assertIsInstance(test_tasks.noop_task_from_bare_decorator, Task)
-        self.assertIsInstance(test_tasks.noop_task_async_from_bare_decorator, Task)
 
     def test_enqueue_task(self) -> None:
         result = test_tasks.noop_task.enqueue()

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -8,6 +8,7 @@ from django.utils.module_loading import import_string
 from django_tasks import (
     DEFAULT_QUEUE_NAME,
     ResultStatus,
+    Task,
     default_task_backend,
     task,
     tasks,
@@ -36,6 +37,10 @@ class TaskTestCase(SimpleTestCase):
     def test_using_correct_backend(self) -> None:
         self.assertEqual(default_task_backend, tasks["default"])
         self.assertIsInstance(tasks["default"], DummyBackend)
+
+    def test_task_decorator(self) -> None:
+        self.assertIsInstance(test_tasks.noop_task, Task)
+        self.assertIsInstance(test_tasks.noop_task_from_bare_decorator, Task)
 
     def test_enqueue_task(self) -> None:
         result = test_tasks.noop_task.enqueue()


### PR DESCRIPTION
Closes #48 

Inspired by:

- Django's [@login_required source](https://github.com/django/django/blob/1b21feeb7b490b3c75a06736362b05251ec172a9/django/contrib/auth/decorators.py#L72-L86) for the general structure
- Real Python's ["Creating Decorators With Optional Arguments"](https://realpython.com/primer-on-python-decorators/#creating-decorators-with-optional-arguments) for the asterisk syntax

The use of `@overload` for typing is new to me, but comes straight from [mypy's documentation on decorator factories](https://mypy.readthedocs.io/en/stable/generics.html#decorator-factories):

> Sometimes the same decorator supports both bare calls and calls with arguments. This can be achieved by combining with [@overload](https://docs.python.org/3/library/typing.html#typing.overload) ...

Adam's great post ["Python type hints: how to use @overload"](https://adamj.eu/tech/2021/05/29/python-type-hints-how-to-use-overload/) was also helpful in understanding that concept.
