### PR TITLE
Add configurable transaction management

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ The returned `TaskResult` can be interrogated to query the current state of the 
 
 If the task takes arguments, these can be passed as-is to `enqueue`.
 
+#### Transactions
+
+By default, it's up to the backend to determine whether the task should be enqueued immediately (after calling `.enqueue`) or wait until the end of the current database transaction (if there is one).
+
+This can be configured using the `ENQUEUE_ON_COMMIT` setting. `True` and `False` force the behaviour, and `None` is used to let the backend decide.
+
+```python
+TASKS = {
+    "default": {
+        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+        "ENQUEUE_ON_COMMIT": False
+    }
+}
+```
+
+All built-in backends default to waiting for the end of the transaction (`"ENQUEUE_ON_COMMIT": True`).
+
 ### Executing tasks with the database backend
 
 First, you'll need to add `django_tasks.backends.database`  to `INSTALLED_APPS`, and run `manage.py migrate`.

--- a/django_tasks/backends/database/backend.py
+++ b/django_tasks/backends/database/backend.py
@@ -1,13 +1,13 @@
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any, List, TypeVar
+from typing import TYPE_CHECKING, Any, Iterable, TypeVar
 
 from django.apps import apps
-from django.core.checks import ERROR, CheckMessage
+from django.core.checks import messages
 from django.core.exceptions import ValidationError
 from typing_extensions import ParamSpec
 
 from django_tasks.backends.base import BaseTaskBackend
-from django_tasks.exceptions import ResultDoesNotExist
+from django_tasks.exceptions import InvalidTaskError, ResultDoesNotExist
 from django_tasks.task import Task
 from django_tasks.task import TaskResult as BaseTaskResult
 from django_tasks.utils import json_normalize
@@ -38,6 +38,14 @@ class DatabaseBackend(BaseTaskBackend):
     supports_async_task = True
     supports_get_result = True
     supports_defer = True
+
+    def validate_task(self, task: Task[P, T]) -> None:
+        super().validate_task(task)
+
+        if task.enqueue_on_commit is False:
+            raise InvalidTaskError(
+                "enqueue_on_commit must be True or None when using database backend"
+            )
 
     def _task_to_db_task(
         self, task: Task[P, T], args: P.args, kwargs: P.kwargs
@@ -91,16 +99,21 @@ class DatabaseBackend(BaseTaskBackend):
         except (DBTaskResult.DoesNotExist, ValidationError) as e:
             raise ResultDoesNotExist(result_id) from e
 
-    def check(self, **kwargs: Any) -> List[CheckMessage]:
+    def check(self, **kwargs: Any) -> Iterable[messages.CheckMessage]:
+        yield from super().check(**kwargs)
+
+        backend_name = self.__class__.__name__
+
         if not apps.is_installed("django_tasks.backends.database"):
-            backend_name = self.__class__.__name__
+            yield messages.CheckMessage(
+                messages.ERROR,
+                f"{backend_name} configured as django_tasks backend, but database app not installed",
+                "Insert 'django_tasks.backends.database' in INSTALLED_APPS",
+            )
 
-            return [
-                CheckMessage(
-                    ERROR,
-                    f"{backend_name} configured as django_tasks backend, but database app not installed",
-                    "Insert 'django_tasks.backends.database' in INSTALLED_APPS",
-                )
-            ]
-
-        return []
+        if self.enqueue_on_commit is False:
+            yield messages.CheckMessage(
+                messages.WARNING,
+                f"{backend_name} must enqueue tasks at the end of a transaction",
+                "Ensure ENQUEUE_ON_COMMIT is True or None",
+            )

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -1,7 +1,9 @@
 from copy import deepcopy
+from functools import partial
 from typing import List, TypeVar
 from uuid import uuid4
 
+from django.db import transaction
 from django.utils import timezone
 from typing_extensions import ParamSpec
 
@@ -41,8 +43,11 @@ class DummyBackend(BaseTaskBackend):
             backend=self.alias,
         )
 
-        # Copy the task to prevent mutation issues
-        self.results.append(deepcopy(result))
+        if self._get_enqueue_on_commit_for_task(task) is not False:
+            # Copy the task to prevent mutation issues
+            transaction.on_commit(partial(self.results.append, deepcopy(result)))
+        else:
+            self.results.append(deepcopy(result))
 
         return result
 

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -1,8 +1,10 @@
+from functools import partial
 from inspect import iscoroutinefunction
 from typing import TypeVar
 from uuid import uuid4
 
 from asgiref.sync import async_to_sync
+from django.db import transaction
 from django.utils import timezone
 from typing_extensions import ParamSpec
 
@@ -18,34 +20,46 @@ P = ParamSpec("P")
 class ImmediateBackend(BaseTaskBackend):
     supports_async_task = True
 
+    def _execute_task(self, task_result: TaskResult) -> None:
+        """
+        Execute the task for the given `TaskResult`, mutating it with the outcome
+        """
+        calling_task_func = (
+            async_to_sync(task_result.task.func)
+            if iscoroutinefunction(task_result.task.func)
+            else task_result.task.func
+        )
+
+        try:
+            task_result._result = json_normalize(
+                calling_task_func(*task_result.args, **task_result.kwargs)
+            )
+            task_result.status = ResultStatus.COMPLETE
+        except Exception:
+            task_result._result = None
+            task_result.status = ResultStatus.FAILED
+
+        task_result.finished_at = timezone.now()
+
     def enqueue(
         self, task: Task[P, T], args: P.args, kwargs: P.kwargs
     ) -> TaskResult[T]:
         self.validate_task(task)
 
-        calling_task_func = (
-            async_to_sync(task.func) if iscoroutinefunction(task.func) else task.func
-        )
-
-        enqueued_at = timezone.now()
-        try:
-            result = json_normalize(calling_task_func(*args, **kwargs))
-            status = ResultStatus.COMPLETE
-        except Exception:
-            result = None
-            status = ResultStatus.FAILED
-
         task_result = TaskResult[T](
             task=task,
             id=str(uuid4()),
-            status=status,
-            enqueued_at=enqueued_at,
-            finished_at=timezone.now(),
+            status=ResultStatus.NEW,
+            enqueued_at=timezone.now(),
+            finished_at=None,
             args=json_normalize(args),
             kwargs=json_normalize(kwargs),
             backend=self.alias,
         )
 
-        task_result._result = result
+        if self._get_enqueue_on_commit_for_task(task) is not False:
+            transaction.on_commit(partial(self._execute_task, task_result))
+        else:
+            self._execute_task(task_result)
 
         return task_result

--- a/django_tasks/checks.py
+++ b/django_tasks/checks.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence
+from typing import Any, Iterable, Sequence
 
 from django.apps.config import AppConfig
 from django.core.checks.messages import CheckMessage
@@ -8,16 +8,11 @@ from django_tasks import tasks
 
 def check_tasks(
     app_configs: Sequence[AppConfig] = None, **kwargs: Any
-) -> List[CheckMessage]:
+) -> Iterable[CheckMessage]:
     """Checks all registered task backends."""
 
-    errors = []
     for backend in tasks.all():
         try:
-            backend_errors = backend.check()
+            yield from backend.check()
         except NotImplementedError:
             pass
-        else:
-            errors.extend(backend_errors)
-
-    return errors

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -56,6 +56,8 @@ class Task(Generic[P, T]):
     run_after: Optional[datetime] = None
     """The earliest this task will run"""
 
+    enqueue_on_commit: Optional[bool] = None
+
     def __post_init__(self) -> None:
         self.get_backend().validate_task(self)
 
@@ -164,6 +166,7 @@ def task(
     priority: int = 0,
     queue_name: str = DEFAULT_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
+    enqueue_on_commit: Optional[bool] = None,
 ) -> Callable[[Callable[P, T]], Task[P, T]]: ...
 
 
@@ -174,6 +177,7 @@ def task(
     priority: int = 0,
     queue_name: str = DEFAULT_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
+    enqueue_on_commit: Optional[bool] = None,
 ) -> Union[Task[P, T], Callable[[Callable[P, T]], Task[P, T]]]:
     """
     A decorator used to create a task.
@@ -182,7 +186,11 @@ def task(
 
     def wrapper(f: Callable[P, T]) -> Task[P, T]:
         return tasks[backend].task_class(
-            priority=priority, func=f, queue_name=queue_name, backend=backend
+            priority=priority,
+            func=f,
+            queue_name=queue_name,
+            backend=backend,
+            enqueue_on_commit=enqueue_on_commit,
         )
 
     if function:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -58,6 +58,6 @@ DATABASES = {
 
 USE_TZ = True
 
-if sys.argv[0] != "test":
+if sys.argv[1] == "runserver":
     DEBUG = True
     TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -29,3 +29,13 @@ def failing_task() -> None:
 @task()
 def exit_task() -> None:
     exit(1)
+
+
+@task(enqueue_on_commit=True)
+def enqueue_on_commit_task() -> None:
+    pass
+
+
+@task(enqueue_on_commit=False)
+def never_enqueue_on_commit_task() -> None:
+    pass

--- a/tests/tests/test_dummy_backend.py
+++ b/tests/tests/test_dummy_backend.py
@@ -1,6 +1,7 @@
 import json
 
-from django.test import SimpleTestCase, override_settings
+from django.db import transaction
+from django.test import SimpleTestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 
 from django_tasks import ResultStatus, default_task_backend, tasks
@@ -124,3 +125,91 @@ class DummyBackendTestCase(SimpleTestCase):
             json.loads(response.content),
             {"result_id": result_id, "result": None, "status": ResultStatus.NEW},
         )
+
+
+class DummyBackendTransactionTestCase(TransactionTestCase):
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.dummy.DummyBackend",
+                "ENQUEUE_ON_COMMIT": True,
+            }
+        }
+    )
+    def test_wait_until_transaction_commit(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            test_tasks.noop_task.enqueue()
+
+            self.assertEqual(len(default_task_backend.results), 0)
+
+        self.assertEqual(len(default_task_backend.results), 1)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.dummy.DummyBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_doesnt_wait_until_transaction_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertFalse(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            test_tasks.noop_task.enqueue()
+
+            self.assertEqual(len(default_task_backend.results), 1)
+
+        self.assertEqual(len(default_task_backend.results), 1)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.dummy.DummyBackend",
+            }
+        }
+    )
+    def test_wait_until_transaction_by_default(self) -> None:
+        self.assertIsNone(default_task_backend.enqueue_on_commit)
+        self.assertIsNone(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            test_tasks.noop_task.enqueue()
+
+            self.assertEqual(len(default_task_backend.results), 0)
+
+        self.assertEqual(len(default_task_backend.results), 1)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.dummy.DummyBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_task_specific_enqueue_on_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertTrue(test_tasks.enqueue_on_commit_task.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(
+                test_tasks.enqueue_on_commit_task
+            )
+        )
+
+        with transaction.atomic():
+            test_tasks.enqueue_on_commit_task.enqueue()
+
+            self.assertEqual(len(default_task_backend.results), 0)
+
+        self.assertEqual(len(default_task_backend.results), 1)

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -1,6 +1,7 @@
 import json
 
-from django.test import SimpleTestCase, override_settings
+from django.db import transaction
+from django.test import SimpleTestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -85,7 +86,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
             await default_task_backend.get_result(123)
 
     async def test_cannot_refresh_result(self) -> None:
-        result = default_task_backend.enqueue(
+        result = await default_task_backend.aenqueue(
             test_tasks.calculate_meaning_of_life, (), {}
         )
 
@@ -136,3 +137,91 @@ class ImmediateBackendTestCase(SimpleTestCase):
             "This backend does not support retrieving or refreshing results.",
         ):
             response = self.client.get(reverse("result", args=[result_id]))
+
+
+class ImmediateBackendTransactionTestCase(TransactionTestCase):
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+                "ENQUEUE_ON_COMMIT": True,
+            }
+        }
+    )
+    def test_wait_until_transaction_commit(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            result = test_tasks.noop_task.enqueue()
+
+            self.assertEqual(result.status, ResultStatus.NEW)
+
+        self.assertEqual(result.status, ResultStatus.COMPLETE)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_doesnt_wait_until_transaction_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertFalse(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            result = test_tasks.noop_task.enqueue()
+
+            self.assertEqual(result.status, ResultStatus.COMPLETE)
+
+        self.assertEqual(result.status, ResultStatus.COMPLETE)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+            }
+        }
+    )
+    def test_wait_until_transaction_by_default(self) -> None:
+        self.assertIsNone(default_task_backend.enqueue_on_commit)
+        self.assertIsNone(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        with transaction.atomic():
+            result = test_tasks.noop_task.enqueue()
+
+            self.assertEqual(result.status, ResultStatus.NEW)
+
+        self.assertEqual(result.status, ResultStatus.COMPLETE)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_task_specific_enqueue_on_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertTrue(test_tasks.enqueue_on_commit_task.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(
+                test_tasks.enqueue_on_commit_task
+            )
+        )
+
+        with transaction.atomic():
+            result = test_tasks.enqueue_on_commit_task.enqueue()
+
+            self.assertEqual(result.status, ResultStatus.NEW)
+
+        self.assertEqual(result.status, ResultStatus.COMPLETE)

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -110,7 +110,7 @@ class TaskTestCase(SimpleTestCase):
         self.assertIsNot(new_task, test_tasks.noop_task)
 
     async def test_refresh_result(self) -> None:
-        result = test_tasks.noop_task.enqueue()
+        result = await test_tasks.noop_task.aenqueue()
 
         original_result = dataclasses.asdict(result)
 
@@ -177,12 +177,13 @@ class TaskTestCase(SimpleTestCase):
         with self.assertRaises(ResultDoesNotExist):
             await test_tasks.noop_task.aget_result("123")
 
-    async def test_get_incorrect_result(self) -> None:
+    def test_get_incorrect_result(self) -> None:
         result = default_task_backend.enqueue(test_tasks.noop_task_async, (), {})
-
         with self.assertRaises(ResultDoesNotExist):
             test_tasks.noop_task.get_result(result.id)
 
+    async def test_get_incorrect_result_async(self) -> None:
+        result = await default_task_backend.aenqueue(test_tasks.noop_task_async, (), {})
         with self.assertRaises(ResultDoesNotExist):
             await test_tasks.noop_task.aget_result(result.id)
 


### PR DESCRIPTION
A solution to #24 

Following the pattern Rails uses, how transactions are handled is now configurable. Either tasks are enqueued when the transaction closes, immediately, or backend-dependent (the built-in ones wait for the transaction).