### PR TITLE
Add initial support for a Celery backend

### DIFF
--- a/django_tasks/backends/celery/__init__.py
+++ b/django_tasks/backends/celery/__init__.py
@@ -1,0 +1,3 @@
+from .backend import CeleryBackend
+
+__all__ = ["CeleryBackend"]

--- a/django_tasks/backends/celery/app.py
+++ b/django_tasks/backends/celery/app.py
@@ -4,7 +4,6 @@ from celery import Celery
 
 from django_tasks.task import DEFAULT_QUEUE_NAME
 
-
 # Set the default Django settings module for the 'celery' program.
 django_settings = os.environ.get('DJANGO_SETTINGS_MODULE')
 if django_settings is None:
@@ -19,3 +18,5 @@ app = Celery('django_tasks')
 app.config_from_object('django.conf:settings', namespace='CELERY')
 
 app.conf.task_default_queue = DEFAULT_QUEUE_NAME
+
+app.autodiscover_tasks()

--- a/django_tasks/backends/celery/app.py
+++ b/django_tasks/backends/celery/app.py
@@ -5,17 +5,17 @@ from celery import Celery
 from django_tasks.task import DEFAULT_QUEUE_NAME
 
 # Set the default Django settings module for the 'celery' program.
-django_settings = os.environ.get('DJANGO_SETTINGS_MODULE')
+django_settings = os.environ.get("DJANGO_SETTINGS_MODULE")
 if django_settings is None:
-    raise ValueError('DJANGO_SETTINGS_MODULE environment variable is not set')
+    raise ValueError("DJANGO_SETTINGS_MODULE environment variable is not set")
 
-app = Celery('django_tasks')
+app = Celery("django_tasks")
 
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object("django.conf:settings", namespace="CELERY")
 
 app.conf.task_default_queue = DEFAULT_QUEUE_NAME
 

--- a/django_tasks/backends/celery/app.py
+++ b/django_tasks/backends/celery/app.py
@@ -1,0 +1,21 @@
+import os
+
+from celery import Celery
+
+from django_tasks.task import DEFAULT_QUEUE_NAME
+
+
+# Set the default Django settings module for the 'celery' program.
+django_settings = os.environ.get('DJANGO_SETTINGS_MODULE')
+if django_settings is None:
+    raise ValueError('DJANGO_SETTINGS_MODULE environment variable is not set')
+
+app = Celery('django_tasks')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+app.conf.task_default_queue = DEFAULT_QUEUE_NAME

--- a/django_tasks/backends/celery/backend.py
+++ b/django_tasks/backends/celery/backend.py
@@ -1,0 +1,43 @@
+from typing import TypeVar
+
+from typing_extensions import ParamSpec
+
+from celery import shared_task
+from celery.local import Proxy as CeleryTaskProxy
+from django_tasks.backends.base import BaseTaskBackend
+from django_tasks.task import Task, TaskResult
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+class CeleryTask(Task):
+
+    celery_task: CeleryTaskProxy
+    """Celery proxy to the task in the current celery app task registry."""
+
+    def __post_init__(self) -> None:
+        # TODO: allow passing extra celery specific parameters?
+        celery_task = shared_task()(self.func)
+        self.celery_task = celery_task
+        return super().__post_init__()
+
+
+class CeleryBackend(BaseTaskBackend):
+    task_class = CeleryTask
+    supports_defer = True
+
+    def enqueue(
+        self, task: Task[P, T], args: P.args, kwargs: P.kwargs
+    ) -> TaskResult[T]:
+        self.validate_task(task)
+
+        apply_async_kwargs = {
+            "eta": task.run_after,
+        }
+        if task.queue_name:
+            apply_async_kwargs["queue"] = task.queue_name
+        if task.priority:
+            apply_async_kwargs["priority"] = task.priority
+        task.celery_task.apply_async(args, kwargs=kwargs, **apply_async_kwargs)

--- a/django_tasks/backends/celery/backend.py
+++ b/django_tasks/backends/celery/backend.py
@@ -1,15 +1,20 @@
+from dataclasses import dataclass
 from typing import TypeVar
 
 from celery import shared_task
 from celery.app import default_app
 from celery.local import Proxy as CeleryTaskProxy
+from django.utils import timezone
 from typing_extensions import ParamSpec
 
 from django_tasks.backends.base import BaseTaskBackend
-from django_tasks.task import Task, TaskResult
+from django_tasks.task import ResultStatus, TaskResult
+from django_tasks.task import Task as BaseTask
+from django_tasks.utils import json_normalize
 
 if not default_app:
     from django_tasks.backends.celery.app import app as celery_app
+
     celery_app.set_default()
 
 
@@ -17,32 +22,49 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
-class CeleryTask(Task):
-
-    celery_task: CeleryTaskProxy
+@dataclass
+class Task(BaseTask[P, T]):
+    celery_task: CeleryTaskProxy = None
     """Celery proxy to the task in the current celery app task registry."""
 
     def __post_init__(self) -> None:
-        # TODO: allow passing extra celery specific parameters?
         celery_task = shared_task()(self.func)
         self.celery_task = celery_task
         return super().__post_init__()
 
 
 class CeleryBackend(BaseTaskBackend):
-    task_class = CeleryTask
+    task_class = Task
     supports_defer = True
 
     def enqueue(
-        self, task: Task[P, T], args: P.args, kwargs: P.kwargs
+        self,
+        task: Task[P, T],  # type: ignore[override]
+        args: P.args,
+        kwargs: P.kwargs,
     ) -> TaskResult[T]:
         self.validate_task(task)
 
-        apply_async_kwargs = {
+        apply_async_kwargs: P.kwargs = {
             "eta": task.run_after,
         }
         if task.queue_name:
             apply_async_kwargs["queue"] = task.queue_name
         if task.priority:
             apply_async_kwargs["priority"] = task.priority
-        task.celery_task.apply_async(args, kwargs=kwargs, **apply_async_kwargs)
+
+        # TODO: a Celery result backend is required to get additional information
+        async_result = task.celery_task.apply_async(
+            args, kwargs=kwargs, **apply_async_kwargs
+        )
+        task_result = TaskResult[T](
+            task=task,
+            id=async_result.id,
+            status=ResultStatus.NEW,
+            enqueued_at=timezone.now(),
+            finished_at=None,
+            args=json_normalize(args),
+            kwargs=json_normalize(kwargs),
+            backend=self.alias,
+        )
+        return task_result

--- a/django_tasks/backends/celery/backend.py
+++ b/django_tasks/backends/celery/backend.py
@@ -1,11 +1,16 @@
 from typing import TypeVar
 
+from celery import shared_task
+from celery.app import default_app
+from celery.local import Proxy as CeleryTaskProxy
 from typing_extensions import ParamSpec
 
-from celery import shared_task
-from celery.local import Proxy as CeleryTaskProxy
 from django_tasks.backends.base import BaseTaskBackend
 from django_tasks.task import Task, TaskResult
+
+if not default_app:
+    from django_tasks.backends.celery.app import app as celery_app
+    celery_app.set_default()
 
 
 T = TypeVar("T")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ dev = [
     "coverage",
     "django-stubs[compatible-mypy]",
     "dj-database-url",
+    "celery",
 ]
 mysql = [
     "mysqlclient"

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "django_tasks",
+    "django_tasks.backends.celery",
     "django_tasks.backends.database",
     "tests",
 ]

--- a/tests/tests/test_celery_backend.py
+++ b/tests/tests/test_celery_backend.py
@@ -1,0 +1,131 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from celery import Celery
+from celery.result import AsyncResult
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from django_tasks import ResultStatus, default_task_backend, task, tasks
+from django_tasks.backends.celery import CeleryBackend
+from django_tasks.backends.celery.backend import _map_priority
+from django_tasks.task import DEFAULT_PRIORITY, DEFAULT_QUEUE_NAME
+
+
+def noop_task(*args: tuple, **kwargs: dict) -> None:
+    return None
+
+
+@override_settings(
+    TASKS={
+        "default": {
+            "BACKEND": "django_tasks.backends.celery.CeleryBackend",
+            "QUEUES": [DEFAULT_QUEUE_NAME, "queue-1"],
+        }
+    }
+)
+class CeleryBackendTestCase(TestCase):
+    def setUp(self) -> None:
+        # register task during setup so it is registered as a Celery task
+        self.task = task()(noop_task)
+
+    def test_using_correct_backend(self) -> None:
+        self.assertEqual(default_task_backend, tasks["default"])
+        self.assertIsInstance(tasks["default"], CeleryBackend)
+
+    def test_check(self) -> None:
+        errors = list(default_task_backend.check())
+
+        self.assertEqual(len(errors), 0)
+
+    @override_settings(INSTALLED_APPS=[])
+    def test_celery_backend_app_missing(self) -> None:
+        errors = list(default_task_backend.check())
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("django_tasks.backends.celery", errors[0].hint)
+
+    def test_enqueue_task(self) -> None:
+        task = self.task
+        assert task.celery_task  # type: ignore[attr-defined]
+
+        # import here so that it is not set as default before registering the task
+        from django_tasks.backends.celery.app import app as celery_app
+
+        self.assertEqual(task.celery_task.app, celery_app)  # type: ignore[attr-defined]
+        with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+            mock_apply_async.return_value = AsyncResult(id="123")
+            result = default_task_backend.enqueue(task, (1,), {"two": 3})
+
+        self.assertEqual(result.id, "123")
+        self.assertEqual(result.status, ResultStatus.NEW)
+        self.assertIsNone(result.started_at)
+        self.assertIsNone(result.finished_at)
+        with self.assertRaisesMessage(ValueError, "Task has not finished yet"):
+            result.result  # noqa:B018
+        self.assertEqual(result.task, task)
+        self.assertEqual(result.args, [1])
+        self.assertEqual(result.kwargs, {"two": 3})
+        expected_priority = _map_priority(DEFAULT_PRIORITY)
+        mock_apply_async.assert_called_once_with(
+            (1,),
+            kwargs={"two": 3},
+            eta=None,
+            priority=expected_priority,
+            queue=DEFAULT_QUEUE_NAME,
+        )
+
+    def test_using_additional_params(self) -> None:
+        with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+            mock_apply_async.return_value = AsyncResult(id="123")
+            run_after = timezone.now() + timedelta(hours=10)
+            result = self.task.using(
+                run_after=run_after, priority=75, queue_name="queue-1"
+            ).enqueue()
+
+        self.assertEqual(result.id, "123")
+        self.assertEqual(result.status, ResultStatus.NEW)
+        mock_apply_async.assert_called_once_with(
+            (), kwargs={}, eta=run_after, priority=7, queue="queue-1"
+        )
+
+    def test_priority_mapping(self) -> None:
+        for priority, expected in [(-100, 0), (-50, 2), (0, 4), (75, 7), (100, 9)]:
+            with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+                mock_apply_async.return_value = AsyncResult(id="123")
+                self.task.using(priority=priority).enqueue()
+
+            mock_apply_async.assert_called_with(
+                (), kwargs={}, eta=None, priority=expected, queue=DEFAULT_QUEUE_NAME
+            )
+
+
+@override_settings(
+    TASKS={
+        "default": {
+            "BACKEND": "django_tasks.backends.celery.CeleryBackend",
+            "QUEUES": [DEFAULT_QUEUE_NAME, "queue-1"],
+        }
+    }
+)
+class CeleryBackendCustomAppTestCase(TestCase):
+    def setUp(self) -> None:
+        self.celery_app = Celery("test_app")
+        self.task = task()(noop_task)
+
+    def tearDown(self) -> None:
+        # restore the default Celery app
+        from django_tasks.backends.celery.app import app as celery_app
+
+        celery_app.set_current()
+        return super().tearDown()
+
+    def test_enqueue_task(self) -> None:
+        task = self.task
+        assert task.celery_task  # type: ignore[attr-defined]
+
+        from django_tasks.backends.celery.app import app as celery_app
+
+        self.assertNotEqual(celery_app, self.celery_app)
+        # it should use the custom Celery app
+        self.assertEqual(task.celery_task.app, self.celery_app)  # type: ignore[attr-defined]

--- a/tests/tests/test_celery_backend.py
+++ b/tests/tests/test_celery_backend.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 
 from celery import Celery
 from celery.result import AsyncResult
-from django.test import TestCase, override_settings
+from django.db import transaction
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.utils import timezone
 
 from django_tasks import ResultStatus, default_task_backend, task, tasks
@@ -16,6 +17,10 @@ def noop_task(*args: tuple, **kwargs: dict) -> None:
     return None
 
 
+def enqueue_on_commit_task(*args: tuple, **kwargs: dict) -> None:
+    pass
+
+
 @override_settings(
     TASKS={
         "default": {
@@ -24,10 +29,13 @@ def noop_task(*args: tuple, **kwargs: dict) -> None:
         }
     }
 )
-class CeleryBackendTestCase(TestCase):
+class CeleryBackendTestCase(TransactionTestCase):
     def setUp(self) -> None:
         # register task during setup so it is registered as a Celery task
         self.task = task()(noop_task)
+        self.enqueue_on_commit_task = task(enqueue_on_commit=True)(
+            enqueue_on_commit_task
+        )
 
     def test_using_correct_backend(self) -> None:
         self.assertEqual(default_task_backend, tasks["default"])
@@ -43,7 +51,7 @@ class CeleryBackendTestCase(TestCase):
         errors = list(default_task_backend.check())
 
         self.assertEqual(len(errors), 1)
-        self.assertIn("django_tasks.backends.celery", errors[0].hint)
+        self.assertIn("django_tasks.backends.celery", errors[0].hint)  # type:ignore[arg-type]
 
     def test_enqueue_task(self) -> None:
         task = self.task
@@ -53,51 +61,113 @@ class CeleryBackendTestCase(TestCase):
         from django_tasks.backends.celery.app import app as celery_app
 
         self.assertEqual(task.celery_task.app, celery_app)  # type: ignore[attr-defined]
-        with patch("celery.app.task.Task.apply_async") as mock_apply_async:
-            mock_apply_async.return_value = AsyncResult(id="123")
-            result = default_task_backend.enqueue(task, (1,), {"two": 3})
+        task_id = "123"
+        with patch("django_tasks.backends.celery.backend.uuid", return_value=task_id):
+            with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+                mock_apply_async.return_value = AsyncResult(id=task_id)
+                result = default_task_backend.enqueue(task, (1,), {"two": 3})
 
-        self.assertEqual(result.id, "123")
+        self.assertEqual(result.id, task_id)
         self.assertEqual(result.status, ResultStatus.NEW)
         self.assertIsNone(result.started_at)
         self.assertIsNone(result.finished_at)
         with self.assertRaisesMessage(ValueError, "Task has not finished yet"):
-            result.result  # noqa:B018
+            result.return_value  # noqa:B018
         self.assertEqual(result.task, task)
-        self.assertEqual(result.args, [1])
+        self.assertEqual(result.args, (1,))
         self.assertEqual(result.kwargs, {"two": 3})
         expected_priority = _map_priority(DEFAULT_PRIORITY)
         mock_apply_async.assert_called_once_with(
             (1,),
             kwargs={"two": 3},
+            task_id=task_id,
             eta=None,
             priority=expected_priority,
             queue=DEFAULT_QUEUE_NAME,
         )
 
     def test_using_additional_params(self) -> None:
-        with patch("celery.app.task.Task.apply_async") as mock_apply_async:
-            mock_apply_async.return_value = AsyncResult(id="123")
-            run_after = timezone.now() + timedelta(hours=10)
-            result = self.task.using(
-                run_after=run_after, priority=75, queue_name="queue-1"
-            ).enqueue()
+        task_id = "123"
+        with patch("django_tasks.backends.celery.backend.uuid", return_value=task_id):
+            with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+                mock_apply_async.return_value = AsyncResult(id=task_id)
+                run_after = timezone.now() + timedelta(hours=10)
+                result = self.task.using(
+                    run_after=run_after, priority=75, queue_name="queue-1"
+                ).enqueue()
 
-        self.assertEqual(result.id, "123")
+        self.assertEqual(result.id, task_id)
         self.assertEqual(result.status, ResultStatus.NEW)
         mock_apply_async.assert_called_once_with(
-            (), kwargs={}, eta=run_after, priority=7, queue="queue-1"
+            [], kwargs={}, task_id=task_id, eta=run_after, priority=7, queue="queue-1"
         )
 
     def test_priority_mapping(self) -> None:
         for priority, expected in [(-100, 0), (-50, 2), (0, 4), (75, 7), (100, 9)]:
-            with patch("celery.app.task.Task.apply_async") as mock_apply_async:
-                mock_apply_async.return_value = AsyncResult(id="123")
-                self.task.using(priority=priority).enqueue()
+            task_id = "123"
+            with patch(
+                "django_tasks.backends.celery.backend.uuid", return_value=task_id
+            ):
+                with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+                    mock_apply_async.return_value = AsyncResult(id=task_id)
+                    self.task.using(priority=priority).enqueue()
 
             mock_apply_async.assert_called_with(
-                (), kwargs={}, eta=None, priority=expected, queue=DEFAULT_QUEUE_NAME
+                [],
+                kwargs={},
+                task_id=task_id,
+                eta=None,
+                priority=expected,
+                queue=DEFAULT_QUEUE_NAME,
             )
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.celery.CeleryBackend",
+                "ENQUEUE_ON_COMMIT": True,
+            }
+        }
+    )
+    def test_wait_until_transaction_commit(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(default_task_backend._get_enqueue_on_commit_for_task(self.task))
+
+        with patch("celery.app.task.Task.apply_async") as mock_apply_async:
+            mock_apply_async.return_value = AsyncResult(id="task_id")
+            with transaction.atomic():
+                self.task.enqueue()
+                assert not mock_apply_async.called
+
+        mock_apply_async.assert_called_once()
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.celery.CeleryBackend",
+            }
+        }
+    )
+    def test_wait_until_transaction_by_default(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(default_task_backend._get_enqueue_on_commit_for_task(self.task))
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.celery.CeleryBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_task_specific_enqueue_on_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertTrue(self.enqueue_on_commit_task.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(
+                self.enqueue_on_commit_task
+            )
+        )
 
 
 @override_settings(


### PR DESCRIPTION
This is an initial PoC for a Celery backend implementation (still in progress, probably requiring some extra work, besides tests).

How to use it:

- Using this `django_tasks` branch in your Django project environment, make sure to also install celery:
`$ pip install celery`

- Update your `settings.py` to set the Celery backend:
```
TASKS = {
    "default": {
        "BACKEND": "django_tasks.backends.celery.CeleryBackend"
    }
}
```
- You can also set extra [celery config](https://docs.celeryq.dev/en/stable/userguide/configuration.html) in `settings.py`  (otherwise it will just use the default values, which should be ok), by defining a `CELERY_*` prefixed setting (e.g. to define `broker_url`, you should add a setting for `CELERY_BROKER_URL`)

- If you don't set a [broker URL](https://docs.celeryq.dev/en/stable/userguide/configuration.html#broker-settings), the expected one would be a local RabbitMQ. You can run it using docker like this:
`$ docker run -d -p 5672:5672 rabbitmq`

- You shouldn't need to change any `django_tasks` related code in your project.

- Finally, to run the Celery worker:
`$ DJANGO_SETTINGS_MODULE=<your_project.settings> celery -A django_tasks.backends.celery.app worker -l INFO`
(this uses a simple default Celery app (see `app.py` below) pulling config from Django settings; it can be [customized](https://docs.celeryq.dev/en/stable/django/first-steps-with-django.html) per project if needed)

Your tasks should now be queued into RabbitMQ and picked/run by the Celery worker.
(FWIW, I have been using this in a simple personal project, things seem to work for me so far).

A few items to discuss:
- Should it be possible to run the worker via a management command? (and then, setting the env var for settings shouldn't be necessary)
- Should it be possible to config a subset of the Celery config through django-tasks? (to eventually handle those general enough for all backends in the same way)
- Right now this tries to keep the simplicity from the current implementation, just wrapping the minimal bits to queue tasks through Celery (and use the Celery worker to handle them on the other side), but eventually it could make sense to get deeper into Celery internals to allow for more flexible and/or complex scenarios (if needed).
- Any other feedback, suggestions or expectations.
