### PR TITLE
Store task exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ result.refresh()
 assert result.status == ResultStatus.COMPLETE
 ```
 
+#### Exceptions
+
+If a task raised an exception, its `.result` will be the exception raised:
+
+```python
+assert isinstance(result.result, ValueError)
+```
+
+As part of the serialization process for exceptions, some information, such as the traceback information, is lost.
+
 ### Backend introspecting
 
 Because `django-tasks` enables support for multiple different backends, those backends may not support all features, and it can be useful to determine this at runtime to ensure the chosen task queue meets the requirements, or to gracefully degrade functionality if it doesn't.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If a task raised an exception, its `.result` will be the exception raised:
 assert isinstance(result.result, ValueError)
 ```
 
-As part of the serialization process for exceptions, some information, such as the traceback information, is lost.
+As part of the serialization process for exceptions, some information, such as the traceback information, is lost. If the exception could not be serialized, the `.result` is `None`.
 
 ### Backend introspecting
 

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -121,7 +121,7 @@ class Worker:
                 db_task_result.task_path,
                 ResultStatus.FAILED,
             )
-            db_task_result.set_failed()
+            db_task_result.set_failed(e)
 
             # If the user tried to terminate, let them
             if isinstance(e, KeyboardInterrupt):

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
@@ -10,6 +11,8 @@ from typing_extensions import ParamSpec
 
 from django_tasks.task import DEFAULT_QUEUE_NAME, ResultStatus, Task
 from django_tasks.utils import exception_to_dict, retry
+
+logger = logging.getLogger("django_tasks.backends.database")
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -147,5 +150,6 @@ class DBTaskResult(GenericBase[P, T], models.Model):
         try:
             self.result = exception_to_dict(exc)
         except Exception:
+            logger.exception("Task id=%s unable to save exception", self.id)
             self.result = None
         self.save(update_fields=["status", "finished_at", "result"])

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -146,6 +146,6 @@ class DBTaskResult(GenericBase[P, T], models.Model):
         self.finished_at = timezone.now()
         try:
             self.result = exception_to_dict(exc)
-        except Exception as e:
-            self.result = exception_to_dict(e)
+        except Exception:
+            self.result = None
         self.save(update_fields=["status", "finished_at", "result"])

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from typing_extensions import ParamSpec
 
 from django_tasks.task import ResultStatus, Task, TaskResult
-from django_tasks.utils import json_normalize
+from django_tasks.utils import exception_to_dict, json_normalize
 
 from .base import BaseTaskBackend
 
@@ -32,8 +32,11 @@ class ImmediateBackend(BaseTaskBackend):
         try:
             result = json_normalize(calling_task_func(*args, **kwargs))
             status = ResultStatus.COMPLETE
-        except Exception:
-            result = None
+        except Exception as e:
+            try:
+                result = exception_to_dict(e)
+            except Exception as encode_e:
+                result = exception_to_dict(encode_e)
             status = ResultStatus.FAILED
 
         task_result = TaskResult[T](

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -1,3 +1,4 @@
+import logging
 from inspect import iscoroutinefunction
 from typing import TypeVar
 from uuid import uuid4
@@ -10,6 +11,9 @@ from django_tasks.task import ResultStatus, Task, TaskResult
 from django_tasks.utils import exception_to_dict, json_normalize
 
 from .base import BaseTaskBackend
+
+logger = logging.getLogger(__name__)
+
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -29,6 +33,7 @@ class ImmediateBackend(BaseTaskBackend):
 
         enqueued_at = timezone.now()
         started_at = timezone.now()
+        result_id = str(uuid4())
         try:
             result = json_normalize(calling_task_func(*args, **kwargs))
             status = ResultStatus.COMPLETE
@@ -36,12 +41,13 @@ class ImmediateBackend(BaseTaskBackend):
             try:
                 result = exception_to_dict(e)
             except Exception:
+                logger.exception("Task id=%s unable to save exception", result_id)
                 result = None
             status = ResultStatus.FAILED
 
         task_result = TaskResult[T](
             task=task,
-            id=str(uuid4()),
+            id=result_id,
             status=status,
             enqueued_at=enqueued_at,
             started_at=started_at,

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -35,8 +35,8 @@ class ImmediateBackend(BaseTaskBackend):
         except Exception as e:
             try:
                 result = exception_to_dict(e)
-            except Exception as encode_e:
-                result = exception_to_dict(encode_e)
+            except Exception:
+                result = None
             status = ResultStatus.FAILED
 
         task_result = TaskResult[T](

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -20,6 +20,7 @@ from django.utils import timezone
 from typing_extensions import ParamSpec, Self
 
 from .exceptions import ResultDoesNotExist
+from .utils import get_module_path
 
 if TYPE_CHECKING:
     from .backends.base import BaseTaskBackend
@@ -147,7 +148,7 @@ class Task(Generic[P, T]):
 
     @property
     def module_path(self) -> str:
-        return f"{self.func.__module__}.{self.func.__qualname__}"
+        return get_module_path(self.func)
 
 
 # Bare decorator usage

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -27,5 +27,10 @@ def failing_task() -> None:
 
 
 @task()
+def complex_exception() -> None:
+    raise ValueError(ValueError("This task failed"))
+
+
+@task()
 def exit_task() -> None:
     exit(1)

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -317,7 +317,9 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         result = test_tasks.complex_exception.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(8), self.assertLogs(
+            "django_tasks.backends.database", level="ERROR"
+        ):
             self.run_worker()
 
         self.assertEqual(result.status, ResultStatus.NEW)

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -328,11 +328,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type: ignore
         self.assertGreaterEqual(result.finished_at, result.started_at)  # type: ignore
         self.assertEqual(result.status, ResultStatus.FAILED)
-        self.assertIsInstance(result.result, TypeError)
-        self.assertEqual(
-            result.result.args[0],  # type: ignore[union-attr]
-            "Object of type ValueError is not JSON serializable",
-        )
+        self.assertIsNone(result.result)
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
 

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -44,6 +44,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 self.assertGreaterEqual(result.started_at, result.enqueued_at)
                 self.assertGreaterEqual(result.finished_at, result.started_at)
                 self.assertIsNone(result.result)
+                self.assertIsNone(result.get_result())
                 self.assertEqual(result.task, task)
                 self.assertEqual(result.args, [])
                 self.assertEqual(result.kwargs, {})
@@ -56,8 +57,26 @@ class ImmediateBackendTestCase(SimpleTestCase):
         self.assertIsNotNone(result.finished_at)
         self.assertGreaterEqual(result.started_at, result.enqueued_at)
         self.assertGreaterEqual(result.finished_at, result.started_at)
-        self.assertIsNone(result.result)
+        self.assertIsInstance(result.result, ValueError)
+        self.assertIsNone(result.get_result())
         self.assertEqual(result.task, test_tasks.failing_task)
+        self.assertEqual(result.args, [])
+        self.assertEqual(result.kwargs, {})
+
+    def test_complex_exception(self) -> None:
+        result = default_task_backend.enqueue(test_tasks.complex_exception, [], {})
+
+        self.assertEqual(result.status, ResultStatus.FAILED)
+        self.assertIsNotNone(result.started_at)
+        self.assertIsNotNone(result.finished_at)
+        self.assertGreaterEqual(result.started_at, result.enqueued_at)
+        self.assertGreaterEqual(result.finished_at, result.started_at)
+        self.assertIsInstance(result.result, TypeError)
+        self.assertEqual(
+            result.result.args[0], "Object of type ValueError is not JSON serializable"
+        )
+        self.assertIsNone(result.get_result())
+        self.assertEqual(result.task, test_tasks.complex_exception)
         self.assertEqual(result.args, [])
         self.assertEqual(result.kwargs, {})
 

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -64,7 +64,8 @@ class ImmediateBackendTestCase(SimpleTestCase):
         self.assertEqual(result.kwargs, {})
 
     def test_complex_exception(self) -> None:
-        result = default_task_backend.enqueue(test_tasks.complex_exception, [], {})
+        with self.assertLogs("django_tasks.backends.immediate", level="ERROR"):
+            result = default_task_backend.enqueue(test_tasks.complex_exception, [], {})
 
         self.assertEqual(result.status, ResultStatus.FAILED)
         self.assertIsNotNone(result.started_at)

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -71,10 +71,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
         self.assertIsNotNone(result.finished_at)
         self.assertGreaterEqual(result.started_at, result.enqueued_at)
         self.assertGreaterEqual(result.finished_at, result.started_at)
-        self.assertIsInstance(result.result, TypeError)
-        self.assertEqual(
-            result.result.args[0], "Object of type ValueError is not JSON serializable"
-        )
+        self.assertIsNone(result.result, TypeError)
         self.assertIsNone(result.get_result())
         self.assertEqual(result.task, test_tasks.complex_exception)
         self.assertEqual(result.args, [])

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -72,7 +72,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
         self.assertIsNotNone(result.finished_at)
         self.assertGreaterEqual(result.started_at, result.enqueued_at)
         self.assertGreaterEqual(result.finished_at, result.started_at)
-        self.assertIsNone(result.result, TypeError)
+        self.assertIsNone(result.result)
         self.assertIsNone(result.get_result())
         self.assertEqual(result.task, test_tasks.complex_exception)
         self.assertEqual(result.args, [])

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -2,9 +2,11 @@ import datetime
 import subprocess
 from unittest.mock import Mock
 
+from django.core.exceptions import ImproperlyConfigured
 from django.test import SimpleTestCase
 
 from django_tasks import utils
+from django_tasks.exceptions import InvalidTaskError
 from tests import tasks as test_tasks
 
 
@@ -85,3 +87,30 @@ class RetryTestCase(SimpleTestCase):
     def test_keeps_return_value(self) -> None:
         self.assertTrue(utils.retry()(lambda: True)())
         self.assertFalse(utils.retry()(lambda: False)())
+
+
+class ExceptionSerializationTestCase(SimpleTestCase):
+    def test_serialize_exceptions(self) -> None:
+        for exc in [
+            ValueError(10),
+            SyntaxError("Wrong"),
+            ImproperlyConfigured("It's wrong"),
+            InvalidTaskError(""),
+        ]:
+            with self.subTest(exc):
+                data = utils.exception_to_dict(exc)
+                self.assertEqual(utils.json_normalize(data), data)
+                self.assertEqual(set(data.keys()), {"exc_type", "exc_args"})
+                reconstructed = utils.exception_from_dict(data)
+                self.assertIsInstance(reconstructed, type(exc))
+                self.assertEqual(reconstructed.args, exc.args)
+
+    def test_cannot_deserialize_non_exception(self) -> None:
+        for data in [
+            {"exc_type": "subprocess.check_output", "exc_args": ["exit", "1"]},
+            {"exc_type": "True", "exc_args": []},
+            {"exc_type": "math.pi", "exc_args": []},
+        ]:
+            with self.subTest(data):
+                with self.assertRaises((TypeError, ImportError)):
+                    utils.exception_from_dict(data)

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -96,6 +96,7 @@ class ExceptionSerializationTestCase(SimpleTestCase):
             SyntaxError("Wrong"),
             ImproperlyConfigured("It's wrong"),
             InvalidTaskError(""),
+            SystemExit(),
         ]:
             with self.subTest(exc):
                 data = utils.exception_to_dict(exc)
@@ -110,6 +111,9 @@ class ExceptionSerializationTestCase(SimpleTestCase):
             {"exc_type": "subprocess.check_output", "exc_args": ["exit", "1"]},
             {"exc_type": "True", "exc_args": []},
             {"exc_type": "math.pi", "exc_args": []},
+            {"exc_type": __name__, "exc_args": []},
+            {"exc_type": utils.get_module_path(type(self)), "exc_args": []},
+            {"exc_type": utils.get_module_path(Mock), "exc_args": []},
         ]:
             with self.subTest(data):
                 with self.assertRaises((TypeError, ImportError)):


### PR DESCRIPTION
Closes #63 

Tasks can now store the exception they raised, if they raised one.

The serialization process isn't perfect, since it must be JSON-compatible. Some information (such as traceback) is lost as a result. I suspect in most cases, an instance check or extracting the message, which is possible here. The format is internal, so can be expanded in future if needed.