### PR TITLE
Improve concurrency coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,6 @@ TASKS = {
 
 Finally, you can run `manage.py db_worker` to run tasks as they're created. Check the `--help` for more options.
 
-> [!CAUTION]
-> The database backend does not work with SQLite when you are running multiple worker processes - tasks may be executed more than once. See [#33](https://github.com/RealOrangeOne/django-tasks/issues/33).
-
 ### Retrieving task result
 
 When enqueueing a task, you get a `TaskResult`, however it may be useful to retrieve said result from somewhere else (another request, another task etc). This can be done with `get_result` (or `aget_result`):

--- a/django_tasks/backends/base.py
+++ b/django_tasks/backends/base.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from inspect import iscoroutinefunction
-from typing import Any, List, TypeVar
+from typing import Any, Iterable, TypeVar
 
 from asgiref.sync import sync_to_async
 from django.core.checks.messages import CheckMessage
@@ -101,7 +101,7 @@ class BaseTaskBackend(metaclass=ABCMeta):
             result_id=result_id
         )
 
-    def check(self, **kwargs: Any) -> List[CheckMessage]:
+    def check(self, **kwargs: Any) -> Iterable[CheckMessage]:
         raise NotImplementedError(
             "subclasses may provide a check() method to verify that task "
             "backend is configured correctly."

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -62,7 +62,7 @@ class DBTaskResultQuerySet(models.QuerySet):
         """
         Get a job, locking the row and accounting for deadlocks.
         """
-        return self.select_for_update().first()
+        return self.select_for_update(skip_locked=True).first()
 
 
 class DBTaskResult(GenericBase[P, T], models.Model):

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -20,6 +20,8 @@ from django_tasks.task import (
 )
 from django_tasks.utils import exception_to_dict, retry
 
+from .utils import normalize_uuid
+
 logger = logging.getLogger("django_tasks.backends.database")
 
 T = TypeVar("T")
@@ -127,7 +129,7 @@ class DBTaskResult(GenericBase[P, T], models.Model):
         result = TaskResult[T](
             db_result=self,
             task=self.task,
-            id=str(self.id),
+            id=normalize_uuid(self.id),
             status=ResultStatus[self.status],
             enqueued_at=self.enqueued_at,
             started_at=self.started_at,

--- a/django_tasks/backends/database/utils.py
+++ b/django_tasks/backends/database/utils.py
@@ -1,0 +1,23 @@
+from contextlib import contextmanager
+from typing import Any, Generator
+
+from django.db import DEFAULT_DB_ALIAS, connections, transaction
+
+
+@contextmanager
+def exclusive_transaction(using: str = DEFAULT_DB_ALIAS) -> Generator[Any, Any, Any]:
+    """
+    Wrapper around `transaction.atomic` which ensures transactions on SQLite are exclusive.
+
+    This functionality is built-in to Django 5.1+.
+    """
+    if connections[using].vendor == "sqlite":
+        with connections[using].cursor() as c:
+            c.execute("BEGIN EXCLUSIVE")
+            try:
+                yield
+            finally:
+                c.execute("COMMIT")
+    else:
+        with transaction.atomic(using=using):
+            yield

--- a/django_tasks/backends/database/utils.py
+++ b/django_tasks/backends/database/utils.py
@@ -1,19 +1,21 @@
 from contextlib import contextmanager
-from typing import Any, Generator, Union
+from typing import Any, Generator, Optional, Union
 from uuid import UUID
 
-from django.db import DEFAULT_DB_ALIAS, connections, transaction
+from django.db import transaction
 
 
 @contextmanager
-def exclusive_transaction(using: str = DEFAULT_DB_ALIAS) -> Generator[Any, Any, Any]:
+def exclusive_transaction(using: Optional[str] = None) -> Generator[Any, Any, Any]:
     """
     Wrapper around `transaction.atomic` which ensures transactions on SQLite are exclusive.
 
     This functionality is built-in to Django 5.1+.
     """
-    if connections[using].vendor == "sqlite":
-        with connections[using].cursor() as c:
+    connection = transaction.get_connection(using)
+
+    if connection.vendor == "sqlite":
+        with connection.cursor() as c:
             c.execute("BEGIN EXCLUSIVE")
             try:
                 yield

--- a/django_tasks/backends/database/utils.py
+++ b/django_tasks/backends/database/utils.py
@@ -14,7 +14,10 @@ def exclusive_transaction(using: Optional[str] = None) -> Generator[Any, Any, An
     """
     connection = transaction.get_connection(using)
 
-    if connection.vendor == "sqlite":
+    if (
+        connection.vendor == "sqlite"
+        and getattr(connection, "transaction_mode", None) != "EXCLUSIVE"
+    ):
         with connection.cursor() as c:
             c.execute("BEGIN EXCLUSIVE")
             try:

--- a/django_tasks/backends/database/utils.py
+++ b/django_tasks/backends/database/utils.py
@@ -1,5 +1,6 @@
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any, Generator, Union
+from uuid import UUID
 
 from django.db import DEFAULT_DB_ALIAS, connections, transaction
 
@@ -21,3 +22,16 @@ def exclusive_transaction(using: str = DEFAULT_DB_ALIAS) -> Generator[Any, Any, 
     else:
         with transaction.atomic(using=using):
             yield
+
+
+def normalize_uuid(val: Union[str, UUID]) -> str:
+    """
+    Normalize a UUID into its dashed representation.
+
+    This works around engines like MySQL which don't store values in a uuid field,
+    and thus drops the dashes.
+    """
+    if isinstance(val, str):
+        val = UUID(val)
+
+    return str(val)

--- a/django_tasks/checks.py
+++ b/django_tasks/checks.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Sequence
+from typing import Any, Iterable, Sequence
 
 from django.apps.config import AppConfig
 from django.core.checks.messages import CheckMessage
@@ -8,16 +8,11 @@ from django_tasks import tasks
 
 def check_tasks(
     app_configs: Sequence[AppConfig] = None, **kwargs: Any
-) -> List[CheckMessage]:
+) -> Iterable[CheckMessage]:
     """Checks all registered task backends."""
 
-    errors = []
     for backend in tasks.all():
         try:
-            backend_errors = backend.check()
+            yield from backend.check()
         except NotImplementedError:
             pass
-        else:
-            errors.extend(backend_errors)
-
-    return errors

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,7 +5,7 @@ import dj_database_url
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-IN_TEST = sys.argv[0] == "test"
+IN_TEST = sys.argv[1] == "test"
 
 ALLOWED_HOSTS = ["*"]
 

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -547,7 +547,7 @@ class DatabaseTaskResultTestCase(TransactionTestCase):
                 c.execute("PRAGMA journal_mode=wal")
 
     def execute_in_new_connection(self, sql: Union[str, QuerySet]) -> list:
-        if isinstance(sql, QuerySet):  # type:ignore[misc]
+        if isinstance(sql, QuerySet):
             sql = str(sql.query)
         new_connection = connections.create_connection("default")
         try:

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -199,13 +199,13 @@ class DatabaseBackendTestCase(TransactionTestCase):
             _ = db_task_result.task
 
     def test_check(self) -> None:
-        errors = default_task_backend.check()
+        errors = list(default_task_backend.check())
 
         self.assertEqual(len(errors), 0)
 
     @override_settings(INSTALLED_APPS=[])
     def test_database_backend_app_missing(self) -> None:
-        errors = default_task_backend.check()
+        errors = list(default_task_backend.check())
 
         self.assertEqual(len(errors), 1)
         self.assertIn("django_tasks.backends.database", errors[0].hint)


### PR DESCRIPTION
Fixes #33 

This PR uses `EXCLUSIVE` transactions on SQLite, which a task can only be claimed once, at the cost of throughput.

I've also improved the coverage for `get_locked`, ensuring it actually locks rows as it's expected to.