### PR TITLE
Swallow and log any BaseException in ImmediateBackend other than KeyboardInterrupt

### DIFF
--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -37,7 +37,7 @@ class ImmediateBackend(BaseTaskBackend):
         try:
             result = json_normalize(calling_task_func(*args, **kwargs))
             status = ResultStatus.COMPLETE
-        except Exception as e:
+        except BaseException as e:
             try:
                 result = exception_to_dict(e)
             except Exception:
@@ -47,6 +47,10 @@ class ImmediateBackend(BaseTaskBackend):
             # Use `.exception` to integrate with error monitoring tools (eg Sentry)
             logger.exception("Task execution failed: %s", e)
             status = ResultStatus.FAILED
+
+            # If the user tried to terminate, let them
+            if isinstance(e, KeyboardInterrupt):
+                raise
 
         task_result = TaskResult[T](
             task=task,

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -45,7 +45,12 @@ class ImmediateBackend(BaseTaskBackend):
                 result = None
 
             # Use `.exception` to integrate with error monitoring tools (eg Sentry)
-            logger.exception("Task execution failed: %s", e)
+            logger.exception(
+                "Task id=%s path=%s state=%s",
+                result_id,
+                task.module_path,
+                ResultStatus.FAILED,
+            )
             status = ResultStatus.FAILED
 
             # If the user tried to terminate, let them

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -43,6 +43,9 @@ class ImmediateBackend(BaseTaskBackend):
             except Exception:
                 logger.exception("Task id=%s unable to save exception", result_id)
                 result = None
+
+            # Use `.exception` to integrate with error monitoring tools (eg Sentry)
+            logger.exception("Task execution failed: %s", e)
             status = ResultStatus.FAILED
 
         task_result = TaskResult[T](

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -23,17 +23,17 @@ def calculate_meaning_of_life() -> int:
 
 @task()
 def failing_task_value_error() -> None:
-    raise ValueError("This task raised ValueError")
+    raise ValueError("This task failed due to ValueError")
 
 
 @task()
 def failing_task_system_exit() -> None:
-    raise SystemExit("This task raised SystemExit")
+    raise SystemExit("This task failed due to SystemExit")
 
 
 @task()
 def failing_task_keyboard_interrupt() -> None:
-    raise KeyboardInterrupt("This task raised KeyboardInterrupt")
+    raise KeyboardInterrupt("This task failed due to KeyboardInterrupt")
 
 
 @task()

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -22,8 +22,18 @@ def calculate_meaning_of_life() -> int:
 
 
 @task()
-def failing_task() -> None:
-    raise ValueError("This task failed")
+def failing_task_value_error() -> None:
+    raise ValueError("This task raised ValueError")
+
+
+@task()
+def failing_task_system_exit() -> None:
+    raise SystemExit("This task raised SystemExit")
+
+
+@task()
+def failing_task_keyboard_interrupt() -> None:
+    raise KeyboardInterrupt("This task raised KeyboardInterrupt")
 
 
 @task()

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -346,7 +346,11 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertIsInstance(result.result, ValueError)
         assert result.traceback  # So that mypy knows the next line is allowed
-        self.assertTrue(result.traceback.endswith("ValueError: This task failed\n"))
+        self.assertTrue(
+            result.traceback.endswith(
+                "ValueError: This task failed due to ValueError\n"
+            )
+        )
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
 

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -283,7 +283,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
     def test_batch_processes_all_tasks(self) -> None:
         for _ in range(3):
             test_tasks.noop_task.enqueue()
-        test_tasks.failing_task.enqueue()
+        test_tasks.failing_task_value_error.enqueue()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 4)
 
@@ -329,7 +329,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
 
     def test_failing_task(self) -> None:
-        result = test_tasks.failing_task.enqueue()
+        result = test_tasks.failing_task_value_error.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
         with self.assertNumQueries(8):
@@ -374,7 +374,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
 
     def test_doesnt_process_different_backend(self) -> None:
-        result = test_tasks.failing_task.enqueue()
+        result = test_tasks.failing_task_value_error.enqueue()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -50,36 +50,57 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 self.assertEqual(result.kwargs, {})
 
     def test_catches_exception(self) -> None:
-        tasks_with_expected_messages = [
-            (test_tasks.failing_task_value_error, "This task raised ValueError"),
-            (test_tasks.failing_task_system_exit, "This task raised SystemExit"),
+        test_data = [
+            (
+                test_tasks.failing_task_value_error,  # task function
+                ValueError,  # expected exception
+                "This task failed due to ValueError",  # expected message
+            ),
+            (
+                test_tasks.failing_task_system_exit,
+                SystemExit,
+                "This task failed due to SystemExit",
+            ),
         ]
-        for task, message in tasks_with_expected_messages:
-            with self.subTest(task):
-                with self.assertLogs(
-                    "django_tasks.backends.immediate", level="ERROR"
-                ) as captured_logs:
-                    result = default_task_backend.enqueue(task, [], {})
-                    self.assertEqual(len(captured_logs.output), 1)
-                    self.assertIn(message, captured_logs.output[0])
+        for task, exception, message in test_data:
+            with self.subTest(task), self.assertLogs(
+                "django_tasks.backends.immediate", level="ERROR"
+            ) as captured_logs:
+                result = default_task_backend.enqueue(task, [], {})
 
-        self.assertEqual(result.status, ResultStatus.FAILED)
-        self.assertIsNotNone(result.started_at)
-        self.assertIsNotNone(result.finished_at)
-        self.assertGreaterEqual(result.started_at, result.enqueued_at)
-        self.assertGreaterEqual(result.finished_at, result.started_at)
-        self.assertIsInstance(result.result, ValueError)
-        self.assertTrue(result.traceback.endswith("ValueError: This task failed\n"))
-        self.assertIsNone(result.get_result())
-        self.assertEqual(result.task, test_tasks.failing_task)
-        self.assertEqual(result.args, [])
-        self.assertEqual(result.kwargs, {})
+                # assert logging
+                self.assertEqual(len(captured_logs.output), 1)
+                self.assertIn(message, captured_logs.output[0])
+
+                # assert result
+                self.assertEqual(result.status, ResultStatus.FAILED)
+                self.assertIsNotNone(result.started_at)
+                self.assertIsNotNone(result.finished_at)
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)
+                self.assertGreaterEqual(result.finished_at, result.started_at)
+                self.assertIsInstance(result.result, exception)
+                self.assertTrue(
+                    result.traceback.endswith(f"{exception.__name__}: {message}\n")
+                )
+                self.assertIsNone(result.get_result())
+                self.assertEqual(result.task, task)
+                self.assertEqual(result.args, [])
+                self.assertEqual(result.kwargs, {})
 
     def test_throws_keyboard_interrupt(self) -> None:
         with self.assertRaises(KeyboardInterrupt):
-            default_task_backend.enqueue(
-                test_tasks.failing_task_keyboard_interrupt, [], {}
-            )
+            with self.assertLogs(
+                "django_tasks.backends.immediate", level="ERROR"
+            ) as captured_logs:
+                default_task_backend.enqueue(
+                    test_tasks.failing_task_keyboard_interrupt, [], {}
+                )
+
+        # assert logging
+        self.assertEqual(len(captured_logs.output), 1)
+        self.assertIn(
+            "This task failed due to KeyboardInterrupt", captured_logs.output[0]
+        )
 
     def test_complex_exception(self) -> None:
         with self.assertLogs("django_tasks.backends.immediate", level="ERROR"):


### PR DESCRIPTION
Fixes #50 