### PR TITLE
Allow fractional interval argument for database worker

### DIFF
--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -160,7 +160,9 @@ def valid_backend_name(val: str) -> str:
 
 def valid_interval(val: str) -> float:
     num = float(val)
-    if not math.isfinite(num) or num < 0:
+    if not math.isfinite(num):
+        raise ArgumentTypeError("Must be a finite floating point value")
+    if num < 0:
         raise ArgumentTypeError("Must be greater than zero")
     return num
 

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -1,4 +1,5 @@
 import logging
+import math
 import random
 import signal
 import sys
@@ -158,11 +159,8 @@ def valid_backend_name(val: str) -> str:
 
 
 def valid_interval(val: str) -> float:
-    # Cast to an int first to catch invalid values like 'inf'
-    int(val)
-
     num = float(val)
-    if num < 0:
+    if not math.isfinite(num) or num < 0:
         raise ArgumentTypeError("Must be greater than zero")
     return num
 

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -426,7 +426,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
                 execute_from_command_line(
                     ["django-admin", "db_worker", "--interval", "inf"]
                 )
-        self.assertIn("invalid valid_interval value: 'inf'", output.getvalue())
+        self.assertIn("Must be a finite floating point value", output.getvalue())
 
     def test_fractional_interval(self) -> None:
         with mock.patch(


### PR DESCRIPTION
Running the database worker with a fractional interval fails:

```
$ ./manage.py db_worker --interval=.001
...
manage.py db_worker: error: argument --interval: invalid valid_interval value: '.001'
```

There's a built-in way to check if a float value is an actual number (as opposed to `NaN` or `Inf`) which is [`math.isfinite`](https://docs.python.org/3/library/math.html#math.isfinite).