### PR TITLE
Add additional test cases for process management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
         run: just lint
       - name: Run tests
         run: just test
+      - name: Run fast tests
+        run: just test-fast
 
   test-postgres:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -62,8 +62,8 @@ cover/
 # Django stuff:
 *.log
 local_settings.py
-db.sqlite3
-db.sqlite3-journal
+*.sqlite3
+*.sqlite3-journal
 
 # Flask stuff:
 instance/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,9 @@ just test-sqlite
 # To run all of the above:
 just test-dbs
 ```
+
+Due to database worker process' tests, tests cannot run using an in-memory database, which means tests run quite slow locally. If you're not modifying the worker, and want you tests run run quicker, run:
+
+```sh
+just test-fast
+```

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -41,7 +41,7 @@ class Worker:
     def shutdown(self, signum: int, frame: Optional[FrameType]) -> None:
         if not self.running:
             logger.warning(
-                "Received %s - shutting down immediately.", signal.strsignal(signum)
+                "Received %s - terminating current task.", signal.strsignal(signum)
             )
             sys.exit(1)
 
@@ -149,10 +149,6 @@ class Worker:
                     sender=sender,
                     task_result=task_result,
                 )
-
-            # If the user tried to terminate, let them
-            if isinstance(e, KeyboardInterrupt):
-                raise
 
 
 def valid_backend_name(val: str) -> str:

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -27,13 +27,20 @@ logger = logging.getLogger("django_tasks.backends.database.db_worker")
 
 class Worker:
     def __init__(
-        self, *, queue_names: List[str], interval: float, batch: bool, backend_name: str
+        self,
+        *,
+        queue_names: List[str],
+        interval: float,
+        batch: bool,
+        backend_name: str,
+        startup_delay: bool,
     ):
         self.queue_names = queue_names
         self.process_all_queues = "*" in queue_names
         self.interval = interval
         self.batch = batch
         self.backend_name = backend_name
+        self.startup_delay = startup_delay
 
         self.running = True
         self.running_task = False
@@ -67,7 +74,7 @@ class Worker:
 
         logger.info("Starting worker for queues=%s", ",".join(self.queue_names))
 
-        if self.interval:
+        if self.startup_delay and self.interval:
             # Add a random small delay before starting the loop to avoid a thundering herd
             time.sleep(random.random())
 
@@ -201,6 +208,12 @@ class Command(BaseCommand):
             dest="backend_name",
             help="The backend to operate on (default: %(default)r)",
         )
+        parser.add_argument(
+            "--no-startup-delay",
+            action="store_false",
+            dest="startup_delay",
+            help="Don't add a small delay at startup.",
+        )
 
     def configure_logging(self, verbosity: int) -> None:
         if verbosity == 0:
@@ -225,6 +238,7 @@ class Command(BaseCommand):
         interval: float,
         batch: bool,
         backend_name: str,
+        startup_delay: bool,
         **options: dict,
     ) -> None:
         self.configure_logging(verbosity)
@@ -234,6 +248,7 @@ class Command(BaseCommand):
             interval=interval,
             batch=batch,
             backend_name=backend_name,
+            startup_delay=startup_delay,
         )
 
         worker.start()

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -94,7 +94,7 @@ class Worker:
                     except OperationalError as e:
                         # Ignore locked databases and keep trying.
                         # It should unlock eventually.
-                        if "database is locked" in e.args[0]:
+                        if "is locked" in e.args[0]:
                             task_result = None
                         else:
                             raise

--- a/justfile
+++ b/justfile
@@ -9,6 +9,9 @@ test *ARGS:
     python -m coverage report
     python -m coverage html
 
+test-fast *ARGS:
+    python -m manage test --shuffle --noinput --settings tests.settings_fast {{ ARGS }}
+
 format:
     python -m ruff check django_tasks tests --fix
     python -m ruff format django_tasks tests

--- a/justfile
+++ b/justfile
@@ -19,7 +19,6 @@ lint:
     python -m mypy django_tasks tests
 
 start-dbs:
-    docker-compose pull
     docker-compose up -d
 
 test-sqlite *ARGS:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ ignore = ["E501", "DJ008"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/db_worker_test_settings.py" = ["F403", "F405"]
+"tests/settings_fast.py" = ["F403", "F405"]
 
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ postgres = [
 select = ["E", "F", "I", "W", "N", "B", "A", "C4", "T20", "DJ"]
 ignore = ["E501", "DJ008"]
 
+[tool.ruff.lint.per-file-ignores]
+"tests/db_worker_test_settings.py" = ["F403", "F405"]
+
 [tool.mypy]
 plugins = ["mypy_django_plugin.main"]
 warn_unused_ignores = true

--- a/tests/db_worker_test_settings.py
+++ b/tests/db_worker_test_settings.py
@@ -1,0 +1,9 @@
+from .settings import *
+
+TASKS = {"default": {"BACKEND": "django_tasks.backends.database.DatabaseBackend"}}
+
+# Force the test DB to be used
+if "sqlite" in DATABASES["default"]["ENGINE"]:
+    DATABASES["default"]["NAME"] = DATABASES["default"]["TEST"]["NAME"]
+else:
+    DATABASES["default"]["NAME"] = "test_" + DATABASES["default"]["NAME"]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -55,15 +55,17 @@ DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 DATABASES = {
     "default": dj_database_url.config(
-        default="sqlite://:memory:"
-        if IN_TEST
-        else "sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
+        default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
     )
 }
 
 # Set exclusive transactions in 5.1+
 if django.VERSION >= (5, 1) and "sqlite" in DATABASES["default"]["ENGINE"]:
     DATABASES["default"].setdefault("OPTIONS", {})["transaction_mode"] = "EXCLUSIVE"
+
+if "sqlite" in DATABASES["default"]["ENGINE"]:
+    DATABASES["default"]["TEST"] = {"NAME": os.path.join(BASE_DIR, "db-test.sqlite3")}
+
 
 USE_TZ = True
 

--- a/tests/settings_fast.py
+++ b/tests/settings_fast.py
@@ -1,0 +1,5 @@
+from .settings import *
+
+# Unset custom test settings to use in-memory DB
+if "sqlite" in DATABASES["default"]["ENGINE"]:
+    del DATABASES["default"]["TEST"]

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,3 +1,5 @@
+import time
+
 from django_tasks import task
 
 
@@ -54,3 +56,16 @@ def enqueue_on_commit_task() -> None:
 @task(enqueue_on_commit=False)
 def never_enqueue_on_commit_task() -> None:
     pass
+
+
+@task()
+def hang() -> None:
+    """
+    Do nothing for 5 minutes
+    """
+    time.sleep(300)
+
+
+@task()
+def sleep_for(seconds: float) -> None:
+    time.sleep(seconds)

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1177,7 +1177,7 @@ class DatabaseBackendPruneTaskResultsTestCase(TransactionTestCase):
     }
 )
 class DatabaseWorkerProcessTestCase(TransactionTestCase):
-    WORKER_STARTUP_TIME = 0.5
+    WORKER_STARTUP_TIME = 1
 
     def setUp(self) -> None:
         self.processes: List[subprocess.Popen] = []
@@ -1188,7 +1188,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
             for process in self.processes:
                 if process.poll() is None:
                     process.kill()
-                    time.sleep(0.01)
+                    time.sleep(0.1)
 
     def start_worker(
         self, args: Optional[List[str]] = None, debug: bool = False
@@ -1355,7 +1355,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
 
         for process in self.processes:
             process.terminate()
-            process.wait(timeout=3)
+            process.wait(timeout=5)
             self.assertIsNotNone(process.returncode)
 
         for result in results:

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1171,6 +1171,8 @@ class DatabaseBackendPruneTaskResultsTestCase(TransactionTestCase):
     }
 )
 class DatabaseWorkerProcessTestCase(TransactionTestCase):
+    WORKER_STARTUP_TIME = 0.5
+
     def setUp(self) -> None:
         self.processes: List[multiprocessing.Process] = []
 
@@ -1214,7 +1216,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
     def test_interrupt_no_tasks(self) -> None:
         process = self.start_worker(batch=False, interval=1)
 
-        time.sleep(0.01)
+        time.sleep(self.WORKER_STARTUP_TIME)
 
         process.terminate()
 
@@ -1235,7 +1237,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
                 process = self.start_worker(batch=False)
 
                 # Make sure the task is running by now
-                time.sleep(0.01)
+                time.sleep(self.WORKER_STARTUP_TIME)
 
                 result.refresh()
                 self.assertEqual(result.status, ResultStatus.RUNNING)
@@ -1259,13 +1261,13 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
         process = self.start_worker(batch=False)
 
         # Make sure the task is running by now
-        time.sleep(0.01)
+        time.sleep(self.WORKER_STARTUP_TIME)
 
         result.refresh()
         self.assertEqual(result.status, ResultStatus.RUNNING)
 
         os.kill(process.pid, signal.SIGINT)  # type:ignore[arg-type]
-        time.sleep(0.01)
+        time.sleep(0.5)
 
         self.assertTrue(process.is_alive())
         result.refresh()
@@ -1294,7 +1296,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
         process = self.start_worker(batch=False)
 
         # Make sure the task is running by now
-        time.sleep(0.01)
+        time.sleep(self.WORKER_STARTUP_TIME)
 
         result.refresh()
         self.assertEqual(result.status, ResultStatus.RUNNING)
@@ -1343,7 +1345,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
                 for _ in range(3):
                     self.start_worker(batch=False, verbosity=3)
 
-                time.sleep(1)
+                time.sleep(self.WORKER_STARTUP_TIME * 3)
 
                 for process in self.processes:
                     process.terminate()

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -3,6 +3,7 @@ import logging
 import multiprocessing
 import os
 import signal
+import sys
 import tempfile
 import time
 import uuid
@@ -1275,7 +1276,11 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
         self.assertIsInstance(result.exception, SystemExit)
 
     @skipIf(connection.vendor != "sqlite", "SQLite only for now")
+    @skipIf(sys.platform == "win32", "Windows doesn't support SIGKILL")
     def test_kill(self) -> None:
+        # Required to keep mypy happy
+        assert hasattr(signal, "SIGKILL")
+
         result = test_tasks.hang.enqueue()
 
         # Unset "batch" so the worker would never normally terminate

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1174,6 +1174,11 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
     def setUp(self) -> None:
         self.processes: List[multiprocessing.Process] = []
 
+        # The "fork" method must be used to ensure the child processes
+        # are configured correctly for testing.
+        self.initial_start_method = multiprocessing.get_start_method()
+        multiprocessing.set_start_method("fork", force=True)
+
     def tearDown(self) -> None:
         # Try n times to kill any remaining child processes
         for _ in range(3):
@@ -1181,6 +1186,8 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
                 if process.is_alive():
                     process.terminate()
                     time.sleep(0.01)
+
+        multiprocessing.set_start_method(self.initial_start_method, force=True)
 
     def start_worker(self, **kwargs: Any) -> multiprocessing.Process:
         p = multiprocessing.Process(

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1258,7 +1258,9 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
             signal.SIGTERM,
         ]:
             with self.subTest(sig):
-                result = test_tasks.sleep_for.enqueue(1)
+                result = test_tasks.sleep_for.enqueue(2)
+
+                self.assertGreater(result.args[0], self.WORKER_STARTUP_TIME)
 
                 process = self.start_worker()
 
@@ -1270,7 +1272,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
 
                 process.send_signal(sig)
 
-                process.wait(timeout=1)
+                process.wait(timeout=2)
 
                 self.assertEqual(process.returncode, 0)
 

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1208,7 +1208,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
                 *args,
             ],
             stdout=None if debug else subprocess.PIPE,
-            stderr=None if debug else subprocess.PIPE,
+            stderr=None if debug else subprocess.STDOUT,
             env={
                 **os.environ,
                 "DJANGO_SETTINGS_MODULE": "tests.db_worker_test_settings",


### PR DESCRIPTION
Fixes #59 

Unfortunately, SQLite tests are now much slower, as they don't run in memory any more. I've added an extra command to try and mitigate that.

Simulating signals on Windows is rather difficult, so improvements to those tests will come later.