### PR TITLE
Close connections after each task

### DIFF
--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -8,6 +8,7 @@ from types import FrameType
 from typing import List, Optional
 
 from django.core.management.base import BaseCommand
+from django.db import connections
 from django.db.utils import OperationalError
 
 from django_tasks import DEFAULT_TASK_BACKEND_ALIAS, tasks
@@ -96,6 +97,9 @@ class Worker:
 
             finally:
                 self.running_task = False
+
+                for conn in connections.all(initialized_only=True):
+                    conn.close()
 
             if self.batch and task_result is None:
                 # If we're running in "batch" mode, terminate the loop (and thus the worker)

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -267,7 +267,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
                 self.assertEqual(result.status, ResultStatus.NEW)
 
-                with self.assertNumQueries(8):
+                with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
                     self.run_worker()
 
                 self.assertEqual(result.status, ResultStatus.NEW)
@@ -287,7 +287,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 4)
 
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(27 if connection.vendor == "mysql" else 23):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -308,7 +308,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
             self.run_worker(queue_name=result.task.queue_name)
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -323,7 +323,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
             self.run_worker(queue_name="*")
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -332,7 +332,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         result = test_tasks.failing_task_value_error.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
             self.run_worker()
 
         self.assertEqual(result.status, ResultStatus.NEW)
@@ -358,9 +358,9 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         result = test_tasks.complex_exception.enqueue()
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8), self.assertLogs(
-            "django_tasks.backends.database", level="ERROR"
-        ):
+        with self.assertNumQueries(
+            9 if connection.vendor == "mysql" else 8
+        ), self.assertLogs("django_tasks.backends.database", level="ERROR"):
             self.run_worker()
 
         self.assertEqual(result.status, ResultStatus.NEW)
@@ -387,7 +387,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
             self.run_worker(backend_name=result.backend)
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)
@@ -447,7 +447,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 1)
 
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(9 if connection.vendor == "mysql" else 8):
             self.run_worker()
 
         self.assertEqual(DBTaskResult.objects.ready().count(), 0)


### PR DESCRIPTION
This emulates the `request_finished` signal