### PR TITLE
Only sleep if there are no tasks

### DIFF
--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -183,7 +183,7 @@ class Command(BaseCommand):
             nargs="?",
             default=1,
             type=valid_interval,
-            help="The interval (in seconds) at which to check for tasks to process (default: %(default)r)",
+            help="The interval (in seconds) to wait, when there are no tasks in the queue, before checking for tasks again (default: %(default)r)",
         )
         parser.add_argument(
             "--batch",

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -104,7 +104,7 @@ class Worker:
 
             # If ctrl-c has just interrupted a task, self.running was cleared,
             # and we should not sleep, but rather exit immediately.
-            if self.running:
+            if self.running and not task_result:
                 # Wait before checking for another task
                 time.sleep(self.interval)
 


### PR DESCRIPTION
I was running the DB worker on a queue full of tasks, and was wondering why it was only processing one task per second. It's bad form to sleep when there is work to do.