### PR TITLE
Fix linting errors

### DIFF
--- a/django_tasks/__init__.py
+++ b/django_tasks/__init__.py
@@ -4,7 +4,7 @@ import django_stubs_ext
 django_stubs_ext.monkeypatch()
 
 import importlib.metadata
-from typing import Mapping, Optional, cast
+from typing import Any, Optional, cast
 
 from django.utils.connection import BaseConnectionHandler, ConnectionProxy
 from django.utils.module_loading import import_string
@@ -67,4 +67,4 @@ class TasksHandler(BaseConnectionHandler[BaseTaskBackend]):
 
 tasks = TasksHandler()
 
-default_task_backend = ConnectionProxy(cast(Mapping, tasks), DEFAULT_TASK_BACKEND_ALIAS)
+default_task_backend = cast(Any, ConnectionProxy(tasks, DEFAULT_TASK_BACKEND_ALIAS))

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -777,7 +777,7 @@ class DatabaseTaskResultTestCase(TransactionTestCase):
                     normalize_uuid(result_2.id),
                 )
                 self.assertEqual(
-                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore[union-attr, arg-type]
+                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore[union-attr]
                     normalize_uuid(result_2.id),
                 )
         finally:


### PR DESCRIPTION
The CI currently fails because a new version of Mypy is raising new errors.