### PR TITLE
Add Django 5.1 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0", "5.1rc1"]
+        django-version: ["4.2", "5.0", "5.1"]
         exclude:
           - django-version: "5.0"
             python-version: "3.8"
           - django-version: "5.0"
             python-version: "3.9"
-          - django-version: "5.1rc1"
+          - django-version: "5.1"
             python-version: "3.8"
-          - django-version: "5.1rc1"
+          - django-version: "5.1"
             python-version: "3.9"
           - os: windows-latest  # JSON1 is only built-in on 3.9+
             python-version: 3.8
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0", "5.1rc1"]
+        django-version: ["4.2", "5.0", "5.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0", "5.1rc1"]
+        django-version: ["4.2", "5.0", "5.1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,15 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django-version: ["4.2", "5.0"]
+        django-version: ["4.2", "5.0", "5.1rc1"]
         exclude:
           - django-version: "5.0"
             python-version: "3.8"
           - django-version: "5.0"
+            python-version: "3.9"
+          - django-version: "5.1rc1"
+            python-version: "3.8"
+          - django-version: "5.1rc1"
             python-version: "3.9"
           - os: windows-latest  # JSON1 is only built-in on 3.9+
             python-version: 3.8
@@ -60,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0"]
+        django-version: ["4.2", "5.0", "5.1rc1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12
@@ -95,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0"]
+        django-version: ["4.2", "5.0", "5.1rc1"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 4.2",
     "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Natural Language :: English",

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 import dj_database_url
+import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -60,6 +61,9 @@ DATABASES = {
     )
 }
 
+# Set exclusive transactions in 5.1+
+if django.VERSION >= (5, 1) and "sqlite" in DATABASES["default"]["ENGINE"]:
+    DATABASES["default"].setdefault("OPTIONS", {})["transaction_mode"] = "EXCLUSIVE"
 
 USE_TZ = True
 

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -7,12 +7,13 @@ from io import StringIO
 from typing import Sequence, Union, cast
 from unittest import skipIf
 
+import django
 from django.core.exceptions import SuspiciousOperation
 from django.core.management import call_command, execute_from_command_line
 from django.db import connection, connections, transaction
 from django.db.models import QuerySet
 from django.db.utils import IntegrityError, OperationalError
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -22,7 +23,11 @@ from django_tasks.backends.database.management.commands.db_worker import (
     logger as db_worker_logger,
 )
 from django_tasks.backends.database.models import DBTaskResult
-from django_tasks.backends.database.utils import exclusive_transaction, normalize_uuid
+from django_tasks.backends.database.utils import (
+    connection_requires_manual_exclusive_transaction,
+    exclusive_transaction,
+    normalize_uuid,
+)
 from django_tasks.exceptions import ResultDoesNotExist
 from tests import tasks as test_tasks
 
@@ -201,7 +206,7 @@ class DatabaseBackendTestCase(TransactionTestCase):
     def test_check(self) -> None:
         errors = list(default_task_backend.check())
 
-        self.assertEqual(len(errors), 0)
+        self.assertEqual(len(errors), 0, errors)
 
     @override_settings(INSTALLED_APPS=[])
     def test_database_backend_app_missing(self) -> None:
@@ -777,8 +782,46 @@ class DatabaseTaskResultTestCase(TransactionTestCase):
                     normalize_uuid(result_2.id),
                 )
                 self.assertEqual(
-                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore[union-attr]
+                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore[union-attr,arg-type]
                     normalize_uuid(result_2.id),
                 )
         finally:
             new_connection.close()
+
+
+class ConnectionExclusiveTranscationTestCase(TestCase):
+    def setUp(self) -> None:
+        self.connection = connections.create_connection("default")
+
+    def tearDown(self) -> None:
+        self.connection.close()
+
+    @skipIf(connection.vendor == "sqlite", "SQLite handled separately")
+    def test_non_sqlite(self) -> None:
+        self.assertFalse(
+            connection_requires_manual_exclusive_transaction(self.connection)
+        )
+
+    @skipIf(
+        django.VERSION >= (5, 1),
+        "Newer Django versions support custom transaction modes",
+    )
+    @skipIf(connection.vendor != "sqlite", "SQLite only")
+    def test_old_django_requires_manual_transaction(self) -> None:
+        self.assertTrue(
+            connection_requires_manual_exclusive_transaction(self.connection)
+        )
+
+    @skipIf(django.VERSION < (5, 1), "Old Django versions require manual transactions")
+    @skipIf(connection.vendor != "sqlite", "SQLite only")
+    def test_explicit_transaction(self) -> None:
+        # HACK: Set the attribute manually
+        self.connection.transaction_mode = None  # type:ignore[attr-defined]
+        self.assertTrue(
+            connection_requires_manual_exclusive_transaction(self.connection)
+        )
+
+        self.connection.transaction_mode = "EXCLUSIVE"  # type:ignore[attr-defined]
+        self.assertFalse(
+            connection_requires_manual_exclusive_transaction(self.connection)
+        )

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -782,7 +782,7 @@ class DatabaseTaskResultTestCase(TransactionTestCase):
                     normalize_uuid(result_2.id),
                 )
                 self.assertEqual(
-                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore[union-attr,arg-type]
+                    normalize_uuid(DBTaskResult.objects.get_locked().id),  # type:ignore
                     normalize_uuid(result_2.id),
                 )
         finally:


### PR DESCRIPTION
This PR also improves validation of SQLite exclusive transactions, as the previous functionality was brittle and untested.

Therefore, versions prior to this PR should be considered unsupported of Django 5.1+.