### PR TITLE
Improve justfile to manage virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env_*
 .venv
 env/
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,20 @@ git clone git@github.com:your-username/django-tasks.git
 ```
 
 Set up a venv:
+Use the [just](https://just.systems/man/en/) command runner to build the virtual environment:
 
 ```sh
-python -m venv .venv
-source .venv/bin/activate
-python -m pip install -e '.[dev]'
+just setup-env
 ```
 
 > [!TIP]
-> Add an extra name for each database you want to develop with (e.g. `[dev,mysql]`,  `[dev,postgres]` or `[dev,mysql,postgres]`). This is optional.
+> Add an extra name for each database you want to develop with (e.g. `mysql`,  `postgres` or even `mysql postgres`). This is optional:
 
-Then you can run the tests with the [just](https://just.systems/man/en/) command runner:
+```sh
+just setup-env postgres mysql
+```
+
+Then you can run the tests:
 
 ```sh
 just test

--- a/justfile
+++ b/justfile
@@ -1,29 +1,42 @@
+# Variables
+PYTHON_VERSION := shell("python -c \"import sys;v=f'{sys.version_info.major}.{sys.version_info.minor}';sys.stdout.write(v)\"")
+ENV_DIR := ".env_python" + PYTHON_VERSION
+IN_ENV := ". " + ENV_DIR / "/bin/activate &&"
+PIP_CMD := "python" + PYTHON_VERSION + " -m pip --disable-pip-version-check --no-input --retries 2"
+
 # Recipes
 @default:
   just --list
 
+setup-env *args:
+  @python{{PYTHON_VERSION}} -m venv {{ENV_DIR}} --upgrade-deps
+  @{{IN_ENV}} {{PIP_CMD}} install -e .[{{trim_end_match("dev," + replace(trim(args), " ", ","), ",")}}]
+
 test *ARGS:
-    python -m manage check
-    python -m manage makemigrations --dry-run --check --noinput
-    python -m coverage run --source=django_tasks -m manage test --shuffle --noinput {{ ARGS }}
-    python -m coverage report
-    python -m coverage html
+    {{IN_ENV}} python -m manage check
+    {{IN_ENV}} python -m manage makemigrations --dry-run --check --noinput
+    {{IN_ENV}} python -m coverage run --source=django_tasks -m manage test --shuffle --noinput {{ ARGS }}
+    {{IN_ENV}} python -m coverage report
+    {{IN_ENV}} python -m coverage html
 
 format:
-    python -m ruff check django_tasks tests --fix
-    python -m ruff format django_tasks tests
+    {{IN_ENV}} python -m ruff check django_tasks tests --fix
+    {{IN_ENV}} python -m ruff format django_tasks tests
 
 lint:
-    python -m ruff check django_tasks tests
-    python -m ruff format django_tasks tests --check
-    python -m mypy django_tasks tests
+    {{IN_ENV}} python -m ruff check django_tasks tests
+    {{IN_ENV}} python -m ruff format django_tasks tests --check
+    {{IN_ENV}} python -m mypy django_tasks tests
+
+mypy:
+    {{IN_ENV}} python -m mypy django_tasks tests
 
 start-dbs:
     docker-compose pull
     docker-compose up -d
 
 test-sqlite *ARGS:
-    python -m manage test --shuffle --noinput {{ ARGS }}
+    {{IN_ENV}} python -m manage test --shuffle --noinput {{ ARGS }}
 
 test-postgres *ARGS:
     DATABASE_URL=postgres://postgres:postgres@localhost:15432/postgres python -m manage test --shuffle --noinput {{ ARGS }}
@@ -32,3 +45,15 @@ test-mysql *ARGS:
     DATABASE_URL=mysql://root:django@127.0.0.1:13306/django python -m manage test --shuffle --noinput {{ ARGS }}
 
 test-dbs *ARGS: start-dbs test-postgres test-mysql test-sqlite
+
+git-clean: clean
+  @git fsck
+  @git reflog expire --expire=now --all
+  @git repack -ad
+  @git prune
+
+clean:
+  @git clean -dfX >> /dev/null 2>&1
+  @rm -rf {{ENV_DIR}}
+  @rm -rf .env*
+  @rm -rf .venv*


### PR DESCRIPTION
Improve the justfile by adding a target to build the virtual environment for you

- Added just target: ``setup-env``
- Test commands are automatically run within the virtual environment without it needing to be activated locally
- ``setup-env`` target is parameterized for optional dependencies such as *postgres* and *mysql*
- Updated ``CONTRIBUTING.md`` accordingly
- Pip commands are run with options to disable some annoying output, avoid waiting for user input, and to fail faster when the upstream repository cannot be reached
- The virtual environment folder is setup to contain the Python version number so that if[when] the default Python version changes it won't try to use an outdated env and yield obtuse confusing errors