### PR TITLE
Signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Additionally, each `Task` has its own signals. These signals are only sent for t
 
 - `Task.finished`: Called when the task finishes (`COMPLETE` or `FAILED`). There is no sender (`None`), however the handler is called with the finished `task_result`.
 
+Tasks which are modified by `.using` have the same signal.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute.

--- a/README.md
+++ b/README.md
@@ -231,6 +231,19 @@ assert default_task_backend.supports_get_result
 
 This is particularly useful in combination with Django's [system check framework](https://docs.djangoproject.com/en/stable/topics/checks/).
 
+### Signals
+
+A few [Signals](https://docs.djangoproject.com/en/stable/topics/signals/) are provided to more easily respond to certain task events.
+
+Whilst signals are available, they may not be the most maintainable approach.
+
+- `django_tasks.signals.task_enqueued`: Called when a task is enqueued. The sender is the backend class. Also called with the enqueued `task_result`.
+- `django_tasks.signals.task_finished`: Called when a task finishes (`COMPLETE` or `FAILED`). The sender is the backend class. Also called with the finished `task_result`.
+
+Additionally, each `Task` has its own signals. These signals are only sent for the given `Task`, whilst the above will be called for all `Task`s.
+
+- `Task.finished`: Called when the task finishes (`COMPLETE` or `FAILED`). There is no sender (`None`), however the handler is called with the finished `task_result`.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute.

--- a/README.md
+++ b/README.md
@@ -240,12 +240,6 @@ Whilst signals are available, they may not be the most maintainable approach.
 - `django_tasks.signals.task_enqueued`: Called when a task is enqueued. The sender is the backend class. Also called with the enqueued `task_result`.
 - `django_tasks.signals.task_finished`: Called when a task finishes (`COMPLETE` or `FAILED`). The sender is the backend class. Also called with the finished `task_result`.
 
-Additionally, each `Task` has its own signals. These signals are only sent for the given `Task`, whilst the above will be called for all `Task`s.
-
-- `Task.finished`: Called when the task finishes (`COMPLETE` or `FAILED`). There is no sender (`None`), however the handler is called with the finished `task_result`.
-
-Tasks which are modified by `.using` have the same signal.
-
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for information on how to contribute.

--- a/django_tasks/__init__.py
+++ b/django_tasks/__init__.py
@@ -16,6 +16,7 @@ from .task import (
     DEFAULT_TASK_BACKEND_ALIAS,
     ResultStatus,
     Task,
+    TaskResult,
     task,
 )
 
@@ -28,6 +29,7 @@ __all__ = [
     "task",
     "ResultStatus",
     "Task",
+    "TaskResult",
 ]
 
 

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -134,6 +134,7 @@ class Worker:
             # Setting the return and success value inside the error handling,
             # So errors setting it (eg JSON encode) can still be recorded
             db_task_result.set_complete(return_value)
+            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(
                 sender=type(task.get_backend()), task_result=db_task_result.task_result
             )
@@ -145,6 +146,7 @@ class Worker:
             except (ModuleNotFoundError, SuspiciousOperation):
                 logger.exception("Task id=%s failed unexpectedly", db_task_result.id)
             else:
+                task_result.task.finished.send(sender=None, task_result=task_result)
                 task_finished.send(
                     sender=sender,
                     task_result=task_result,

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -134,7 +134,6 @@ class Worker:
             # Setting the return and success value inside the error handling,
             # So errors setting it (eg JSON encode) can still be recorded
             db_task_result.set_complete(return_value)
-            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(
                 sender=type(task.get_backend()), task_result=db_task_result.task_result
             )
@@ -146,7 +145,6 @@ class Worker:
             except (ModuleNotFoundError, SuspiciousOperation):
                 logger.exception("Task id=%s failed unexpectedly", db_task_result.id)
             else:
-                task_result.task.finished.send(sender=None, task_result=task_result)
                 task_finished.send(
                     sender=sender,
                     task_result=task_result,

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -29,7 +29,7 @@ class DummyBackend(BaseTaskBackend):
         self.results = []
 
     def _store_result(self, result: TaskResult) -> None:
-        result.enqueued_at = timezone.now()
+        object.__setattr__(result, "enqueued_at", timezone.now())
         self.results.append(result)
         task_enqueued.send(type(self), task_result=result)
 

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from typing_extensions import ParamSpec
 
 from django_tasks.exceptions import ResultDoesNotExist
+from django_tasks.signals import task_enqueued
 from django_tasks.task import ResultStatus, Task, TaskResult
 from django_tasks.utils import json_normalize
 
@@ -27,6 +28,11 @@ class DummyBackend(BaseTaskBackend):
 
         self.results = []
 
+    def _store_result(self, result: TaskResult) -> None:
+        result.enqueued_at = timezone.now()
+        self.results.append(result)
+        task_enqueued.send(type(self), task_result=result)
+
     def enqueue(
         self, task: Task[P, T], args: P.args, kwargs: P.kwargs
     ) -> TaskResult[T]:
@@ -36,7 +42,7 @@ class DummyBackend(BaseTaskBackend):
             task=task,
             id=str(uuid4()),
             status=ResultStatus.NEW,
-            enqueued_at=timezone.now(),
+            enqueued_at=None,
             started_at=None,
             finished_at=None,
             args=json_normalize(args),
@@ -45,12 +51,12 @@ class DummyBackend(BaseTaskBackend):
         )
 
         if self._get_enqueue_on_commit_for_task(task) is not False:
-            # Copy the task to prevent mutation issues
-            transaction.on_commit(partial(self.results.append, deepcopy(result)))
+            transaction.on_commit(partial(self._store_result, result))
         else:
-            self.results.append(deepcopy(result))
+            self._store_result(result)
 
-        return result
+        # Copy the task to prevent mutation issues
+        return deepcopy(result)
 
     # We don't set `supports_get_result` as the results are scoped to the current thread
     def get_result(self, result_id: str) -> TaskResult:

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.utils import timezone
 from typing_extensions import ParamSpec
 
-from django_tasks.signals import task_enqueued
+from django_tasks.signals import task_enqueued, task_finished
 from django_tasks.task import ResultStatus, Task, TaskResult
 from django_tasks.utils import exception_to_dict, json_normalize
 
@@ -29,7 +29,7 @@ class ImmediateBackend(BaseTaskBackend):
         """
         Execute the task for the given `TaskResult`, mutating it with the outcome
         """
-        task_result.enqueued_at = timezone.now()
+        object.__setattr__(task_result, "enqueued_at", timezone.now())
         task_enqueued.send(type(self), task_result=task_result)
 
         task = task_result.task
@@ -48,27 +48,24 @@ class ImmediateBackend(BaseTaskBackend):
                 ),
             )
         except BaseException as e:
+            # If the user tried to terminate, let them
+            if isinstance(e, KeyboardInterrupt):
+                raise
+
             object.__setattr__(task_result, "finished_at", timezone.now())
             try:
                 object.__setattr__(task_result, "_exception_data", exception_to_dict(e))
             except Exception:
                 logger.exception("Task id=%s unable to save exception", task_result.id)
 
-            # Use `.exception` to integrate with error monitoring tools (eg Sentry)
-            logger.exception(
-                "Task id=%s path=%s state=%s",
-                task_result.id,
-                task.module_path,
-                ResultStatus.FAILED,
-            )
             object.__setattr__(task_result, "status", ResultStatus.FAILED)
 
-            # If the user tried to terminate, let them
-            if isinstance(e, KeyboardInterrupt):
-                raise
+            task_finished.send(type(self), task_result=task_result)
         else:
             object.__setattr__(task_result, "finished_at", timezone.now())
             object.__setattr__(task_result, "status", ResultStatus.COMPLETE)
+
+            task_finished.send(type(self), task_result=task_result)
 
     def enqueue(
         self, task: Task[P, T], args: P.args, kwargs: P.kwargs

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -60,13 +60,11 @@ class ImmediateBackend(BaseTaskBackend):
 
             object.__setattr__(task_result, "status", ResultStatus.FAILED)
 
-            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(type(self), task_result=task_result)
         else:
             object.__setattr__(task_result, "finished_at", timezone.now())
             object.__setattr__(task_result, "status", ResultStatus.COMPLETE)
 
-            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(type(self), task_result=task_result)
 
     def enqueue(

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -60,11 +60,13 @@ class ImmediateBackend(BaseTaskBackend):
 
             object.__setattr__(task_result, "status", ResultStatus.FAILED)
 
+            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(type(self), task_result=task_result)
         else:
             object.__setattr__(task_result, "finished_at", timezone.now())
             object.__setattr__(task_result, "status", ResultStatus.COMPLETE)
 
+            task_result.task.finished.send(sender=None, task_result=task_result)
             task_finished.send(type(self), task_result=task_result)
 
     def enqueue(

--- a/django_tasks/signals.py
+++ b/django_tasks/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+task_enqueued = Signal()

--- a/django_tasks/signals.py
+++ b/django_tasks/signals.py
@@ -1,3 +1,4 @@
 from django.dispatch import Signal
 
 task_enqueued = Signal()
+task_finished = Signal()

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -229,7 +229,7 @@ class TaskResult(Generic[T]):
     status: ResultStatus
     """The status of the running task"""
 
-    enqueued_at: datetime
+    enqueued_at: Optional[datetime]
     """The time this task was enqueued"""
 
     started_at: Optional[datetime]

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -18,6 +18,7 @@ from typing import (
 from asgiref.sync import async_to_sync, sync_to_async
 from django.db.models.enums import TextChoices
 from django.utils import timezone
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import ParamSpec, Self
 
@@ -169,6 +170,17 @@ class Task(Generic[P, T]):
     @property
     def module_path(self) -> str:
         return get_module_path(self.func)
+
+    @property
+    def original(self) -> Self:
+        return cast(Self, import_string(self.module_path))
+
+    @property
+    def is_modified(self) -> bool:
+        """
+        Has this task been modified with `.using`.
+        """
+        return self != self.original
 
 
 # Bare decorator usage

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -19,6 +19,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from django.db.models.enums import TextChoices
 from django.dispatch import Signal
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from typing_extensions import ParamSpec, Self
@@ -186,7 +187,7 @@ class Task(Generic[P, T]):
     def module_path(self) -> str:
         return get_module_path(self.func)
 
-    @property
+    @cached_property
     def original(self) -> Self:
         return cast(Self, import_string(self.module_path))
 
@@ -200,7 +201,7 @@ class Task(Generic[P, T]):
     @property
     def finished(self) -> Signal:
         """A signal, fired when the task finished"""
-        return _get_task_signal(self, "finished")
+        return _get_task_signal(self.original, "finished")
 
 
 # Bare decorator usage

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import uuid
 from contextlib import redirect_stderr
 from datetime import timedelta
@@ -19,9 +20,6 @@ from django.utils import timezone
 
 from django_tasks import ResultStatus, Task, default_task_backend, tasks
 from django_tasks.backends.database import DatabaseBackend
-from django_tasks.backends.database.management.commands.db_worker import (
-    logger as db_worker_logger,
-)
 from django_tasks.backends.database.management.commands.prune_db_task_results import (
     logger as prune_db_tasks_logger,
 )
@@ -352,9 +350,11 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
     run_worker = partial(call_command, "db_worker", verbosity=0, batch=True, interval=0)
 
     def tearDown(self) -> None:
+        logger = logging.getLogger("django_tasks")
+
         # Reset the logger after every run, to ensure the correct `stdout` is used
-        for handler in db_worker_logger.handlers:
-            db_worker_logger.removeHandler(handler)
+        for handler in logger.handlers:
+            logger.removeHandler(handler)
 
     def test_run_enqueued_task(self) -> None:
         for task in [

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -330,6 +330,14 @@ class DatabaseBackendTestCase(TransactionTestCase):
             )
         )
 
+    def test_enqueue_logs(self) -> None:
+        with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
+            result = test_tasks.noop_task.enqueue()
+
+        self.assertEqual(len(captured_logs.output), 1)
+        self.assertIn("enqueued", captured_logs.output[0])
+        self.assertIn(result.id, captured_logs.output[0])
+
 
 @override_settings(
     TASKS={
@@ -366,7 +374,7 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
                 result.refresh()
                 self.assertIsNotNone(result.started_at)
                 self.assertIsNotNone(result.finished_at)
-                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type]
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type,misc]
                 self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type,misc]
                 self.assertEqual(result.status, ResultStatus.COMPLETE)
 

--- a/tests/tests/test_dummy_backend.py
+++ b/tests/tests/test_dummy_backend.py
@@ -138,6 +138,14 @@ class DummyBackendTestCase(SimpleTestCase):
             )
         )
 
+    def test_enqueue_logs(self) -> None:
+        with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
+            result = test_tasks.noop_task.enqueue()
+
+        self.assertEqual(len(captured_logs.output), 1)
+        self.assertIn("enqueued", captured_logs.output[0])
+        self.assertIn(result.id, captured_logs.output[0])
+
 
 class DummyBackendTransactionTestCase(TransactionTestCase):
     @override_settings(

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -65,7 +65,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
         ]
         for task, exception, message in test_data:
             with self.subTest(task), self.assertLogs(
-                "django_tasks.backends.immediate", level="ERROR"
+                "django_tasks", level="ERROR"
             ) as captured_logs:
                 result = task.enqueue()
 
@@ -90,21 +90,16 @@ class ImmediateBackendTestCase(SimpleTestCase):
 
     def test_throws_keyboard_interrupt(self) -> None:
         with self.assertRaises(KeyboardInterrupt):
-            with self.assertLogs(
-                "django_tasks.backends.immediate", level="ERROR"
-            ) as captured_logs:
+            with self.assertLogs("django_tasks", level="ERROR") as captured_logs:
                 default_task_backend.enqueue(
                     test_tasks.failing_task_keyboard_interrupt, [], {}
                 )
 
         # assert logging
-        self.assertEqual(len(captured_logs.output), 1)
-        self.assertIn(
-            "This task failed due to KeyboardInterrupt", captured_logs.output[0]
-        )
+        self.assertEqual(len(captured_logs.output), 0)
 
     def test_complex_exception(self) -> None:
-        with self.assertLogs("django_tasks.backends.immediate", level="ERROR"):
+        with self.assertLogs("django_tasks", level="ERROR"):
             result = test_tasks.complex_exception.enqueue()
 
         self.assertEqual(result.status, ResultStatus.FAILED)
@@ -213,7 +208,6 @@ class ImmediateBackendTestCase(SimpleTestCase):
         with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
             result = test_tasks.noop_task.enqueue()
 
-        self.assertEqual(len(captured_logs.output), 1)
         self.assertIn("enqueued", captured_logs.output[0])
         self.assertIn(result.id, captured_logs.output[0])
 

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -28,7 +28,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 self.assertEqual(result.status, ResultStatus.COMPLETE)
                 self.assertIsNotNone(result.started_at)
                 self.assertIsNotNone(result.finished_at)
-                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type]
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type, misc]
                 self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type, misc]
                 self.assertIsNone(result.return_value)
                 self.assertEqual(result.task, task)
@@ -43,7 +43,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 self.assertEqual(result.status, ResultStatus.COMPLETE)
                 self.assertIsNotNone(result.started_at)
                 self.assertIsNotNone(result.finished_at)
-                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type]
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type, misc]
                 self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type, misc]
                 self.assertIsNone(result.return_value)
                 self.assertEqual(result.task, task)
@@ -77,7 +77,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 self.assertEqual(result.status, ResultStatus.FAILED)
                 self.assertIsNotNone(result.started_at)
                 self.assertIsNotNone(result.finished_at)
-                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type]
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type, misc]
                 self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type, misc]
                 self.assertIsInstance(result.exception, exception)
                 self.assertTrue(
@@ -110,7 +110,7 @@ class ImmediateBackendTestCase(SimpleTestCase):
         self.assertEqual(result.status, ResultStatus.FAILED)
         self.assertIsNotNone(result.started_at)
         self.assertIsNotNone(result.finished_at)
-        self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type]
+        self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type,misc]
         self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type,misc]
 
         self.assertIsNone(result._return_value)
@@ -208,6 +208,14 @@ class ImmediateBackendTestCase(SimpleTestCase):
                 test_tasks.enqueue_on_commit_task
             )
         )
+
+    def test_enqueue_logs(self) -> None:
+        with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
+            result = test_tasks.noop_task.enqueue()
+
+        self.assertEqual(len(captured_logs.output), 1)
+        self.assertIn("enqueued", captured_logs.output[0])
+        self.assertIn(result.id, captured_logs.output[0])
 
 
 class ImmediateBackendTransactionTestCase(TransactionTestCase):

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -266,5 +266,9 @@ class TaskTestCase(SimpleTestCase):
             test_tasks.noop_task.using().finished, test_tasks.noop_task.finished
         )
         self.assertIs(
+            test_tasks.noop_task.using(priority=10).finished,
+            test_tasks.noop_task.finished,
+        )
+        self.assertIs(
             deepcopy(test_tasks.noop_task).finished, test_tasks.noop_task.finished
         )

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -51,7 +51,7 @@ class TaskTestCase(SimpleTestCase):
         result = test_tasks.noop_task.enqueue()
 
         self.assertEqual(result.status, ResultStatus.NEW)
-        self.assertIs(result.task, test_tasks.noop_task)
+        self.assertEqual(result.task, test_tasks.noop_task)
         self.assertEqual(result.args, [])
         self.assertEqual(result.kwargs, {})
 
@@ -61,7 +61,7 @@ class TaskTestCase(SimpleTestCase):
         result = await test_tasks.noop_task.aenqueue()
 
         self.assertEqual(result.status, ResultStatus.NEW)
-        self.assertIs(result.task, test_tasks.noop_task)
+        self.assertEqual(result.task, test_tasks.noop_task)
         self.assertEqual(result.args, [])
         self.assertEqual(result.kwargs, {})
 

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -1,8 +1,6 @@
 import dataclasses
-from copy import deepcopy
 from datetime import datetime, timedelta
 
-from django.dispatch import Signal
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 from django.utils.module_loading import import_string
@@ -259,16 +257,3 @@ class TaskTestCase(SimpleTestCase):
     def test_is_modified(self) -> None:
         self.assertFalse(test_tasks.noop_task.is_modified)
         self.assertTrue(test_tasks.noop_task.using(priority=10).is_modified)
-
-    def test_finished_signal(self) -> None:
-        self.assertIsInstance(test_tasks.noop_task.finished, Signal)
-        self.assertIs(
-            test_tasks.noop_task.using().finished, test_tasks.noop_task.finished
-        )
-        self.assertIs(
-            test_tasks.noop_task.using(priority=10).finished,
-            test_tasks.noop_task.finished,
-        )
-        self.assertIs(
-            deepcopy(test_tasks.noop_task).finished, test_tasks.noop_task.finished
-        )

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -1,6 +1,7 @@
-import dataclasses
+from copy import deepcopy
 from datetime import datetime, timedelta
 
+from django.dispatch import Signal
 from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 from django.utils.module_loading import import_string
@@ -116,15 +117,15 @@ class TaskTestCase(SimpleTestCase):
     async def test_refresh_result(self) -> None:
         result = await test_tasks.noop_task.aenqueue()
 
-        original_result = dataclasses.asdict(result)
+        original_result = deepcopy(result)
 
         result.refresh()
 
-        self.assertEqual(dataclasses.asdict(result), original_result)
+        self.assertEqual(result, original_result)
 
         await result.arefresh()
 
-        self.assertEqual(dataclasses.asdict(result), original_result)
+        self.assertEqual(result, original_result)
 
     def test_naive_datetime(self) -> None:
         with self.assertRaisesMessage(
@@ -245,3 +246,9 @@ class TaskTestCase(SimpleTestCase):
     def test_is_modified(self) -> None:
         self.assertFalse(test_tasks.noop_task.is_modified)
         self.assertTrue(test_tasks.noop_task.using(priority=10).is_modified)
+
+    def test_finished_signal(self) -> None:
+        self.assertIsInstance(test_tasks.noop_task.finished, Signal)
+        self.assertIs(
+            test_tasks.noop_task.using().finished, test_tasks.noop_task.finished
+        )

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -232,3 +232,16 @@ class TaskTestCase(SimpleTestCase):
             import_string(test_tasks.noop_task_async.module_path),
             test_tasks.noop_task_async,
         )
+
+    def test_original(self) -> None:
+        self.assertEqual(test_tasks.noop_task, test_tasks.noop_task.original)
+        self.assertNotEqual(
+            test_tasks.noop_task.using(priority=10), test_tasks.noop_task
+        )
+        self.assertEqual(
+            test_tasks.noop_task.using(priority=10).original, test_tasks.noop_task
+        )
+
+    def test_is_modified(self) -> None:
+        self.assertFalse(test_tasks.noop_task.is_modified)
+        self.assertTrue(test_tasks.noop_task.using(priority=10).is_modified)


### PR DESCRIPTION
Use signals as a very basic method of hooking into the task lifecycle. Whether for task chaining or additional monitoring.

Notably, signals benefit from the existing exception handling, meaning the user doesn't need to work that out for themselves.