### PR TITLE
Prevent writing to task results

### DIFF
--- a/django_tasks/backends/database/backend.py
+++ b/django_tasks/backends/database/backend.py
@@ -21,7 +21,7 @@ T = TypeVar("T")
 P = ParamSpec("P")
 
 
-@dataclass
+@dataclass(frozen=True)
 class TaskResult(BaseTaskResult[T]):
     db_result: "DBTaskResult"
 

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -148,8 +148,8 @@ class DBTaskResult(GenericBase[P, T], models.Model):
             backend=self.backend_name,
         )
 
-        result._return_value = self.return_value
-        result._exception_data = self.exception_data
+        object.__setattr__(result, "_return_value", self.return_value)
+        object.__setattr__(result, "_exception_data", self.exception_data)
 
         return result
 

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -34,15 +34,19 @@ class ImmediateBackend(BaseTaskBackend):
             async_to_sync(task.func) if iscoroutinefunction(task.func) else task.func
         )
 
-        task_result.started_at = timezone.now()
+        object.__setattr__(task_result, "started_at", timezone.now())
         try:
-            task_result._return_value = json_normalize(
-                calling_task_func(*task_result.args, **task_result.kwargs)
+            object.__setattr__(
+                task_result,
+                "_return_value",
+                json_normalize(
+                    calling_task_func(*task_result.args, **task_result.kwargs)
+                ),
             )
         except BaseException as e:
-            task_result.finished_at = timezone.now()
+            object.__setattr__(task_result, "finished_at", timezone.now())
             try:
-                task_result._exception_data = exception_to_dict(e)
+                object.__setattr__(task_result, "_exception_data", exception_to_dict(e))
             except Exception:
                 logger.exception("Task id=%s unable to save exception", task_result.id)
 
@@ -53,14 +57,14 @@ class ImmediateBackend(BaseTaskBackend):
                 task.module_path,
                 ResultStatus.FAILED,
             )
-            task_result.status = ResultStatus.FAILED
+            object.__setattr__(task_result, "status", ResultStatus.FAILED)
 
             # If the user tried to terminate, let them
             if isinstance(e, KeyboardInterrupt):
                 raise
         else:
-            task_result.finished_at = timezone.now()
-            task_result.status = ResultStatus.COMPLETE
+            object.__setattr__(task_result, "finished_at", timezone.now())
+            object.__setattr__(task_result, "status", ResultStatus.COMPLETE)
 
     def enqueue(
         self, task: Task[P, T], args: P.args, kwargs: P.kwargs

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -218,7 +218,7 @@ def task(
     return wrapper
 
 
-@dataclass
+@dataclass(frozen=True)
 class TaskResult(Generic[T]):
     task: Task
     """The task for which this is a result"""
@@ -292,7 +292,7 @@ class TaskResult(Generic[T]):
         refreshed_task = self.task.get_backend().get_result(self.id)
 
         for attr in TASK_REFRESH_ATTRS:
-            setattr(self, attr, getattr(refreshed_task, attr))
+            object.__setattr__(self, attr, getattr(refreshed_task, attr))
 
     async def arefresh(self) -> None:
         """
@@ -301,4 +301,4 @@ class TaskResult(Generic[T]):
         refreshed_task = await self.task.get_backend().aget_result(self.id)
 
         for attr in TASK_REFRESH_ATTRS:
-            setattr(self, attr, getattr(refreshed_task, attr))
+            object.__setattr__(self, attr, getattr(refreshed_task, attr))

--- a/tests/tests/test_dummy_backend.py
+++ b/tests/tests/test_dummy_backend.py
@@ -74,7 +74,7 @@ class DummyBackendTestCase(SimpleTestCase):
         )
 
         enqueued_result = default_task_backend.results[0]  # type:ignore[attr-defined]
-        enqueued_result.status = ResultStatus.COMPLETE
+        object.__setattr__(enqueued_result, "status", ResultStatus.COMPLETE)
 
         self.assertEqual(result.status, ResultStatus.NEW)
         result.refresh()
@@ -86,7 +86,7 @@ class DummyBackendTestCase(SimpleTestCase):
         )
 
         enqueued_result = default_task_backend.results[0]  # type:ignore[attr-defined]
-        enqueued_result.status = ResultStatus.COMPLETE
+        object.__setattr__(enqueued_result, "status", ResultStatus.COMPLETE)
 
         self.assertEqual(result.status, ResultStatus.NEW)
         await result.arefresh()


### PR DESCRIPTION
Attributes of a `TaskResult` should never be updated, since in most cases it doesn't do anything. Making them `frozen` prevents this, and as a side-benefit allows them to be hashed.

The code which actually does it gets slower, but it prevents a number of potential foot-guns to be worth it. `object.__setattr__` is the escape-hatch [the docs recommend](https://docs.python.org/3/library/dataclasses.html#frozen-instances).