### PR TITLE
Add Django 5.1+ support for `CheckConstraint condition` with backward compatibility

### DIFF
--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -113,7 +113,7 @@ class DBTaskResult(GenericBase[P, T], models.Model):
         if django.VERSION >= (5, 1):
             constraints = [
                 CheckConstraint(
-                    condition=Q(priority__range=(MIN_PRIORITY, MAX_PRIORITY)),
+                    condition=Q(priority__range=(MIN_PRIORITY, MAX_PRIORITY)),  # type: ignore
                     name="priority_range",
                 )
             ]


### PR DESCRIPTION
This PR adds support for `CheckConstraint.condition` in Django 5.1 while maintaining backward compatibility with Django 4.2 by dynamically selecting between condition and check based on the Django version.
