### PR TITLE
Don't enforce UUIDs for task ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ result_id = result.id
 calculate_meaning_of_life.get_result(result_id)
 ```
 
+A result `id` should be considered an opaque string, whose length could be up to 64 characters. ID generation is backend-specific.
+
 Only tasks of the same type can be retrieved this way. To retrieve the result of any task, you can call `get_result` on the backend:
 
 ```python

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -1,7 +1,6 @@
 from copy import deepcopy
 from functools import partial
 from typing import List, TypeVar
-from uuid import uuid4
 
 from django.db import transaction
 from django.utils import timezone
@@ -10,7 +9,7 @@ from typing_extensions import ParamSpec
 from django_tasks.exceptions import ResultDoesNotExist
 from django_tasks.signals import task_enqueued
 from django_tasks.task import ResultStatus, Task, TaskResult
-from django_tasks.utils import json_normalize
+from django_tasks.utils import get_random_id, json_normalize
 
 from .base import BaseTaskBackend
 
@@ -40,7 +39,7 @@ class DummyBackend(BaseTaskBackend):
 
         result = TaskResult[T](
             task=task,
-            id=str(uuid4()),
+            id=get_random_id(),
             status=ResultStatus.NEW,
             enqueued_at=None,
             started_at=None,

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -2,7 +2,6 @@ import logging
 from functools import partial
 from inspect import iscoroutinefunction
 from typing import TypeVar
-from uuid import uuid4
 
 from asgiref.sync import async_to_sync
 from django.db import transaction
@@ -11,7 +10,7 @@ from typing_extensions import ParamSpec
 
 from django_tasks.signals import task_enqueued, task_finished
 from django_tasks.task import ResultStatus, Task, TaskResult
-from django_tasks.utils import exception_to_dict, json_normalize
+from django_tasks.utils import exception_to_dict, get_random_id, json_normalize
 
 from .base import BaseTaskBackend
 
@@ -74,7 +73,7 @@ class ImmediateBackend(BaseTaskBackend):
 
         task_result = TaskResult[T](
             task=task,
-            id=str(uuid4()),
+            id=get_random_id(),
             status=ResultStatus.NEW,
             enqueued_at=None,
             started_at=None,

--- a/django_tasks/utils.py
+++ b/django_tasks/utils.py
@@ -1,10 +1,12 @@
 import inspect
 import json
+import random
 import time
 from functools import wraps
 from traceback import format_exception
 from typing import Any, Callable, List, TypedDict, TypeVar
 
+from django.utils.crypto import RANDOM_STRING_CHARS
 from django.utils.module_loading import import_string
 from typing_extensions import ParamSpec
 
@@ -87,3 +89,15 @@ def exception_from_dict(exc_data: SerializedExceptionDict) -> BaseException:
         raise TypeError(f"{type(exc_class)} is not an exception")
 
     return exc_class(*exc_data["exc_args"])
+
+
+def get_random_id() -> str:
+    """
+    Return a random string for use as a task id.
+
+    Whilst 64 characters is the max, just use 32 as a sensible middle-ground.
+
+    This should be much faster than Django's `get_random_string`, since
+    it's not cryptographically secure.
+    """
+    return "".join(random.choices(RANDOM_STRING_CHARS, k=32))

--- a/tests/tests/test_utils.py
+++ b/tests/tests/test_utils.py
@@ -163,3 +163,13 @@ class ExceptionSerializationTestCase(SimpleTestCase):
             with self.subTest(data):
                 with self.assertRaises((TypeError, ImportError)):
                     utils.exception_from_dict(data)
+
+
+class RandomIdTestCase(SimpleTestCase):
+    def test_correct_length(self) -> None:
+        self.assertEqual(len(utils.get_random_id()), 32)
+
+    def test_random_ish(self) -> None:
+        random_ids = [utils.get_random_id() for _ in range(1000)]
+
+        self.assertEqual(len(random_ids), len(set(random_ids)))


### PR DESCRIPTION
Still used for DB backend, since it has some DB engine optimisations. The rest can be simple opaque strings