### PR TITLE
Fix README for `.exception_class`

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ assert result.status == ResultStatus.SUCCEEDED
 If a task raised an exception, its `.exception_class` will be the exception class raised:
 
 ```python
-assert result.exception == ValueError
+assert result.exception_class == ValueError
 ```
 
 Note that this is just the type of exception, and contains no other values. The traceback information is reduced to a string that you can print to help debugging:


### PR DESCRIPTION
Tiny README tweak, because results don't have an `exception`:

```
In [6]: result = default_task_backend.get_result("7d9d8e82-e62c-4fb2-8305-8e79b24d77c6")

In [7]: result.exception
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[7], line 1
----> 1 result.exception

AttributeError: 'TaskResult' object has no attribute 'exception'

In [8]: result.exception_class
Out[8]: subprocess.CalledProcessError
```