### PR TITLE
Don't require exclusive transactions for entire SQLite DB

### DIFF
--- a/django_tasks/backends/database/backend.py
+++ b/django_tasks/backends/database/backend.py
@@ -2,11 +2,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import django
 from django.apps import apps
 from django.core.checks import messages
 from django.core.exceptions import ValidationError
-from django.db import connections, router, transaction
+from django.db import transaction
 from typing_extensions import ParamSpec
 
 from django_tasks.backends.base import BaseTaskBackend
@@ -81,9 +80,6 @@ class DatabaseBackend(BaseTaskBackend):
             raise ResultDoesNotExist(result_id) from e
 
     def check(self, **kwargs: Any) -> Iterable[messages.CheckMessage]:
-        from .models import DBTaskResult
-        from .utils import connection_requires_manual_exclusive_transaction
-
         yield from super().check(**kwargs)
 
         backend_name = self.__class__.__name__
@@ -92,17 +88,4 @@ class DatabaseBackend(BaseTaskBackend):
             yield messages.Error(
                 f"{backend_name} configured as django_tasks backend, but database app not installed",
                 "Insert 'django_tasks.backends.database' in INSTALLED_APPS",
-            )
-
-        db_connection = connections[router.db_for_read(DBTaskResult)]
-        # Manually called to set `transaction_mode`
-        db_connection.get_connection_params()
-        if (
-            # Versions below 5.1 can't be configured, so always assume exclusive transactions
-            django.VERSION >= (5, 1)
-            and connection_requires_manual_exclusive_transaction(db_connection)
-        ):
-            yield messages.Error(
-                f"{backend_name} is using SQLite non-exclusive transactions",
-                f"Set settings.DATABASES[{db_connection.alias!r}]['OPTIONS']['transaction_mode'] to 'EXCLUSIVE'",
             )

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,7 +2,6 @@ import os
 import sys
 
 import dj_database_url
-import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -58,10 +57,6 @@ DATABASES = {
         default="sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")
     )
 }
-
-# Set exclusive transactions in 5.1+
-if django.VERSION >= (5, 1) and "sqlite" in DATABASES["default"]["ENGINE"]:
-    DATABASES["default"].setdefault("OPTIONS", {})["transaction_mode"] = "EXCLUSIVE"
 
 if "sqlite" in DATABASES["default"]["ENGINE"]:
     DATABASES["default"]["TEST"] = {"NAME": os.path.join(BASE_DIR, "db-test.sqlite3")}


### PR DESCRIPTION
When reading tasks from the task queue, the connection must be exclusive to ensure a task isn't picked up by multiple workers. However, no other queries need this exclusive lock. By removing the requirement for a completely `EXCLUSIVE` database connection, it should drastically improve the throughput of the rest of the application. All whilst not impacting correctness of the worker at all.