### PR TITLE
Add RQ backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A few backends are included by default:
 - `django_tasks.backends.dummy.DummyBackend`: Don't execute the tasks, just store them. This is especially useful for testing.
 - `django_tasks.backends.immediate.ImmediateBackend`: Execute the task immediately in the current thread
 - `django_tasks.backends.database.DatabaseBackend`: Store tasks in the database (via Django's ORM), and retrieve and execute them using the `db_worker` management command
-- `django_tasks.backends.rq.RQBackend`: A backend which enqueues tasks using [RQ](https://python-rq.org/) via [`django-rq`](https://github.com/rq/django-rq).
+- `django_tasks.backends.rq.RQBackend`: A backend which enqueues tasks using [RQ](https://python-rq.org/) via [`django-rq`](https://github.com/rq/django-rq) (requires installing `django-tasks[rq]`).
 
 Note: `DatabaseBackend` additionally requires `django_tasks.backends.database` adding to `INSTALLED_APPS`.
 

--- a/django_tasks/backends/rq.py
+++ b/django_tasks/backends/rq.py
@@ -1,0 +1,229 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Any, Optional, TypeVar
+
+import django_rq
+from django.apps import apps
+from django.core.checks import messages
+from django.core.exceptions import SuspiciousOperation
+from django.db import transaction
+from django.utils.module_loading import import_string
+from redis.client import Redis
+from rq.job import Callback, JobStatus
+from rq.job import Job as BaseJob
+from rq.registry import ScheduledJobRegistry
+from typing_extensions import ParamSpec
+
+from django_tasks.backends.base import BaseTaskBackend
+from django_tasks.exceptions import ResultDoesNotExist
+from django_tasks.signals import task_enqueued, task_finished
+from django_tasks.task import DEFAULT_PRIORITY, MAX_PRIORITY, ResultStatus, Task
+from django_tasks.task import TaskResult as BaseTaskResult
+from django_tasks.utils import get_module_path, get_random_id
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+RQ_STATUS_TO_RESULT_STATUS = {
+    JobStatus.QUEUED: ResultStatus.NEW,
+    JobStatus.FINISHED: ResultStatus.SUCCEEDED,
+    JobStatus.FAILED: ResultStatus.FAILED,
+    JobStatus.STARTED: ResultStatus.RUNNING,
+    JobStatus.DEFERRED: ResultStatus.NEW,
+    JobStatus.SCHEDULED: ResultStatus.NEW,
+    JobStatus.STOPPED: ResultStatus.FAILED,
+    JobStatus.CANCELED: ResultStatus.FAILED,
+    None: ResultStatus.NEW,
+}
+
+
+@dataclass(frozen=True)
+class TaskResult(BaseTaskResult[T]):
+    pass
+
+
+class Job(BaseJob):
+    def _execute(self) -> Any:
+        """
+        Shim RQ's `Job` to call the underlying `Task` function.
+        """
+        return self.func.call(*self.args, **self.kwargs)
+
+    @property
+    def func(self) -> Task:
+        func = super().func
+
+        if not isinstance(func, Task):
+            raise SuspiciousOperation(
+                f"Task {self.id} does not point to a Task ({self.func_name})"
+            )
+
+        return func
+
+    def into_task_result(self) -> TaskResult:
+        task: Task = self.func
+
+        scheduled_job_registry = ScheduledJobRegistry(  # type: ignore[no-untyped-call]
+            queue=django_rq.get_queue(self.origin)
+        )
+
+        if self.is_scheduled:
+            run_after = scheduled_job_registry.get_scheduled_time(self)
+        else:
+            run_after = None
+
+        task_result: TaskResult = TaskResult(
+            task=task.using(
+                priority=DEFAULT_PRIORITY,
+                queue_name=self.origin,
+                run_after=run_after,
+                backend=self.meta["backend_name"],
+            ),
+            id=self.id,
+            status=RQ_STATUS_TO_RESULT_STATUS[self.get_status()],
+            enqueued_at=self.enqueued_at,
+            started_at=self.started_at,
+            finished_at=self.ended_at,
+            args=list(self.args),
+            kwargs=self.kwargs,
+            backend=self.meta["backend_name"],
+        )
+
+        latest_result = self.latest_result()
+
+        if latest_result is not None:
+            if "exception_class" in self.meta:
+                object.__setattr__(
+                    task_result,
+                    "_exception_class",
+                    import_string(self.meta["exception_class"]),
+                )
+            object.__setattr__(task_result, "_traceback", latest_result.exc_string)
+            object.__setattr__(task_result, "_return_value", latest_result.return_value)
+
+        return task_result
+
+
+def failed_callback(
+    job: Job,
+    connection: Optional[Redis],
+    exception_class: type[Exception],
+    exception_value: Exception,
+    traceback: TracebackType,
+) -> None:
+    task_result = job.into_task_result()
+
+    # Smuggle the exception class through meta
+    job.meta["exception_class"] = get_module_path(exception_class)
+    job.save_meta()  # type: ignore[no-untyped-call]
+
+    task_finished.send(type(task_result.task.get_backend()), task_result=task_result)
+
+
+def success_callback(job: Job, connection: Optional[Redis], result: Any) -> None:
+    task_result = job.into_task_result()
+
+    task_finished.send(type(task_result.task.get_backend()), task_result=task_result)
+
+
+class RQBackend(BaseTaskBackend):
+    supports_async_task = True
+    supports_get_result = True
+    supports_defer = True
+
+    def __init__(self, alias: str, params: dict) -> None:
+        super().__init__(alias, params)
+
+        if not self.queues:
+            self.queues = set(django_rq.settings.QUEUES.keys())
+
+    def enqueue(
+        self,
+        task: Task[P, T],
+        args: P.args,  # type:ignore[valid-type]
+        kwargs: P.kwargs,  # type:ignore[valid-type]
+    ) -> TaskResult[T]:
+        self.validate_task(task)
+
+        queue = django_rq.get_queue(task.queue_name, job_class=Job)
+
+        task_result = TaskResult[T](
+            task=task,
+            id=get_random_id(),
+            status=ResultStatus.NEW,
+            enqueued_at=None,
+            started_at=None,
+            finished_at=None,
+            args=args,
+            kwargs=kwargs,
+            backend=self.alias,
+        )
+
+        job = queue.create_job(
+            task.module_path,
+            args=args,
+            kwargs=kwargs,
+            job_id=task_result.id,
+            status=JobStatus.SCHEDULED if task.run_after else JobStatus.QUEUED,
+            on_failure=Callback(failed_callback),
+            on_success=Callback(success_callback),
+            meta={"backend_name": self.alias},
+        )
+
+        def save_result() -> None:
+            nonlocal job
+            if task.run_after is None:
+                job = queue.enqueue_job(job, at_front=task.priority == MAX_PRIORITY)
+            else:
+                job = queue.schedule_job(job, task.run_after)
+
+            object.__setattr__(task_result, "enqueued_at", job.enqueued_at)
+
+            task_enqueued.send(type(self), task_result=task_result)
+
+        if self._get_enqueue_on_commit_for_task(task):
+            transaction.on_commit(save_result)
+        else:
+            save_result()
+
+        return task_result
+
+    def _get_queues(self) -> list[django_rq.queues.DjangoRQ]:
+        return django_rq.queues.get_queues(*self.queues, job_class=Job)  # type: ignore[no-any-return]
+
+    def _get_job(self, job_id: str) -> Optional[Job]:
+        for queue in self._get_queues():
+            job = queue.fetch_job(job_id)
+            if job is not None:
+                return job  # type: ignore[no-any-return]
+
+        return None
+
+    def get_result(self, result_id: str) -> TaskResult:
+        job = self._get_job(result_id)
+
+        if job is None:
+            raise ResultDoesNotExist(result_id)
+
+        return job.into_task_result()
+
+    def check(self, **kwargs: Any) -> Iterable[messages.CheckMessage]:
+        yield from super().check(**kwargs)
+
+        backend_name = self.__class__.__name__
+
+        if not apps.is_installed("django_rq"):
+            yield messages.Error(
+                f"{backend_name} configured as django_tasks backend, but django_rq app not installed",
+                "Insert 'django_rq' in INSTALLED_APPS",
+            )
+
+        for queue_name in self.queues:
+            try:
+                django_rq.get_queue(queue_name)
+            except KeyError:
+                yield messages.Error(
+                    f"{queue_name!r} is not configured for django-rq",
+                    f"Add {queue_name!r} to RQ_QUEUES",
+                )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,18 @@ dev = [
     "coverage",
     "django-stubs[compatible-mypy]",
     "dj-database-url",
+    "django-tasks[rq]",
+    "fakeredis",
 ]
 mysql = [
     "mysqlclient"
 ]
 postgres = [
     "psycopg[binary]",
+]
+rq = [
+    "django-rq",
+    "rq_scheduler",
 ]
 
 [tool.ruff.lint]

--- a/tests/tests/test_rq_backend.py
+++ b/tests/tests/test_rq_backend.py
@@ -1,0 +1,440 @@
+import json
+import os
+import uuid
+from typing import Union, cast
+from unittest.mock import patch
+
+import django_rq
+from asgiref.sync import async_to_sync
+from django.core.exceptions import SuspiciousOperation
+from django.db import transaction
+from django.test import TransactionTestCase, modify_settings, override_settings
+from django.urls import reverse
+from fakeredis import FakeRedis, FakeStrictRedis
+
+from django_tasks import ResultStatus, Task, default_task_backend, tasks
+from django_tasks.backends.rq import Job, RQBackend
+from django_tasks.exceptions import ResultDoesNotExist
+from tests import tasks as test_tasks
+
+
+# RQ
+# Configuration to pretend there is a Redis service available.
+# Set up the connection before RQ Django reads the settings.
+# The connection must be the same because in fakeredis connections
+# do not share the state. Therefore, we define a singleton object to reuse it.
+def get_fake_connection(
+    config: dict, strict: bool
+) -> Union[FakeRedis, FakeStrictRedis]:
+    redis_cls = FakeStrictRedis if strict else FakeRedis
+    if "URL" in config:
+        return redis_cls.from_url(
+            config["URL"],
+            db=config.get("DB"),
+        )
+    return redis_cls(
+        host=config["HOST"],
+        port=config["PORT"],
+        db=config.get("DB", 0),
+        username=config.get("USERNAME", None),
+        password=config.get("PASSWORD"),
+    )
+
+
+@override_settings(
+    TASKS={
+        "default": {
+            "BACKEND": "django_tasks.backends.rq.RQBackend",
+            "QUEUES": ["default", "queue-1"],
+        }
+    },
+    RQ_QUEUES={
+        "default": {
+            "HOST": "localhost",
+            "PORT": 6379,
+        },
+        "queue-1": {
+            "HOST": "localhost",
+            "PORT": 6379,
+        },
+    },
+)
+@modify_settings(INSTALLED_APPS={"append": ["django_rq"]})
+class DatabaseBackendTestCase(TransactionTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        fake_connection_patcher = patch(
+            "django_rq.queues.get_redis_connection", get_fake_connection
+        )
+        fake_connection_patcher.start()
+        self.addCleanup(fake_connection_patcher.stop)
+
+        django_rq.get_connection().flushall()
+
+    def run_worker(self) -> None:
+        from rq import SimpleWorker
+
+        for queue in default_task_backend._get_queues():  # type: ignore[attr-defined]
+            worker = SimpleWorker([queue], prepare_for_work=False, job_class=Job)
+
+            # HACK: Work around fakeredis not supporting `CLIENT LIST`
+            worker.hostname = "example-hostname"
+            worker.pid = os.getpid()
+
+            with self.assertLogs("rq.worker"):
+                worker.work(burst=True)
+
+    def test_using_correct_backend(self) -> None:
+        self.assertEqual(default_task_backend, tasks["default"])
+        self.assertIsInstance(tasks["default"], RQBackend)
+
+    def test_enqueue_task(self) -> None:
+        for task in [test_tasks.noop_task, test_tasks.noop_task_async]:
+            with self.subTest(task):
+                result = cast(Task, task).enqueue(1, two=3)
+
+                self.assertEqual(result.status, ResultStatus.NEW)
+                self.assertFalse(result.is_finished)
+                self.assertIsNone(result.started_at)
+                self.assertIsNone(result.finished_at)
+                with self.assertRaisesMessage(ValueError, "Task has not finished yet"):
+                    result.return_value  # noqa:B018
+                self.assertEqual(result.task, task)
+                self.assertEqual(result.args, [1])
+                self.assertEqual(result.kwargs, {"two": 3})
+
+    async def test_enqueue_task_async(self) -> None:
+        for task in [test_tasks.noop_task, test_tasks.noop_task_async]:
+            with self.subTest(task):
+                result = await cast(Task, task).aenqueue()
+
+                self.assertEqual(result.status, ResultStatus.NEW)
+                self.assertFalse(result.is_finished)
+                self.assertIsNone(result.started_at)
+                self.assertIsNone(result.finished_at)
+                with self.assertRaisesMessage(ValueError, "Task has not finished yet"):
+                    result.return_value  # noqa:B018
+                self.assertEqual(result.task, task)
+                self.assertEqual(result.args, [])
+                self.assertEqual(result.kwargs, {})
+
+    def test_catches_exception(self) -> None:
+        test_data = [
+            (
+                test_tasks.failing_task_value_error,  # task function
+                ValueError,  # expected exception
+                "This task failed due to ValueError",  # expected message
+            ),
+            (
+                test_tasks.failing_task_system_exit,
+                SystemExit,
+                "This task failed due to SystemExit",
+            ),
+        ]
+        for task, exception, message in test_data:
+            with (
+                self.subTest(task),
+            ):
+                result = task.enqueue()
+
+                self.run_worker()
+                result.refresh()
+
+                # assert result
+                self.assertEqual(result.status, ResultStatus.FAILED)
+                with self.assertRaisesMessage(ValueError, "Task failed"):
+                    result.return_value  # noqa: B018
+                self.assertTrue(result.is_finished)
+                self.assertIsNotNone(result.started_at)
+                self.assertIsNotNone(result.finished_at)
+                self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type, misc]
+                self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type, misc]
+                self.assertEqual(result.exception_class, exception)
+                self.assertTrue(
+                    result.traceback
+                    and result.traceback.endswith(f"{exception.__name__}: {message}\n")
+                )
+                self.assertEqual(result.task, task)
+                self.assertEqual(result.args, [])
+                self.assertEqual(result.kwargs, {})
+
+    def test_complex_exception(self) -> None:
+        result = test_tasks.complex_exception.enqueue()
+
+        self.run_worker()
+
+        result.refresh()
+
+        self.assertEqual(result.status, ResultStatus.FAILED)
+        self.assertIsNotNone(result.started_at)
+        self.assertIsNotNone(result.finished_at)
+        self.assertGreaterEqual(result.started_at, result.enqueued_at)  # type:ignore[arg-type,misc]
+        self.assertGreaterEqual(result.finished_at, result.started_at)  # type:ignore[arg-type,misc]
+
+        self.assertIsNone(result._return_value)
+        self.assertEqual(result.exception_class, ValueError)
+        self.assertIn('ValueError(ValueError("This task failed"))', result.traceback)  # type: ignore[arg-type]
+
+        self.assertEqual(result.task, test_tasks.complex_exception)
+        self.assertEqual(result.args, [])
+        self.assertEqual(result.kwargs, {})
+
+    def test_get_result(self) -> None:
+        result = default_task_backend.enqueue(test_tasks.noop_task, [], {})
+
+        new_result = default_task_backend.get_result(result.id)
+
+        self.assertEqual(result, new_result)
+
+    async def test_get_result_async(self) -> None:
+        result = await default_task_backend.aenqueue(test_tasks.noop_task, [], {})
+
+        new_result = await default_task_backend.aget_result(result.id)
+
+        self.assertEqual(result, new_result)
+
+    def test_refresh_result(self) -> None:
+        result = default_task_backend.enqueue(
+            test_tasks.calculate_meaning_of_life, (), {}
+        )
+
+        self.run_worker()
+
+        self.assertEqual(result.status, ResultStatus.NEW)
+        self.assertFalse(result.is_finished)
+        self.assertIsNone(result.started_at)
+        self.assertIsNone(result.finished_at)
+
+        result.refresh()
+
+        self.assertIsNotNone(result.started_at)
+        self.assertIsNotNone(result.finished_at)
+        self.assertEqual(result.status, ResultStatus.SUCCEEDED)
+        self.assertTrue(result.is_finished)
+        self.assertEqual(result.return_value, 42)
+
+    def test_refresh_result_async(self) -> None:
+        result = async_to_sync(default_task_backend.aenqueue)(
+            test_tasks.calculate_meaning_of_life, (), {}
+        )
+
+        self.run_worker()
+
+        self.assertEqual(result.status, ResultStatus.NEW)
+        self.assertFalse(result.is_finished)
+        self.assertIsNone(result.started_at)
+        self.assertIsNone(result.finished_at)
+
+        async_to_sync(result.arefresh)()
+
+        self.assertIsNotNone(result.started_at)
+        self.assertIsNotNone(result.finished_at)
+        self.assertEqual(result.status, ResultStatus.SUCCEEDED)
+        self.assertTrue(result.is_finished)
+        self.assertEqual(result.return_value, 42)
+
+    def test_get_missing_result(self) -> None:
+        with self.assertRaises(ResultDoesNotExist):
+            default_task_backend.get_result(str(uuid.uuid4()))
+
+    async def test_async_get_missing_result(self) -> None:
+        with self.assertRaises(ResultDoesNotExist):
+            await default_task_backend.aget_result(str(uuid.uuid4()))
+
+    def test_invalid_uuid(self) -> None:
+        with self.assertRaises(ResultDoesNotExist):
+            default_task_backend.get_result("123")
+
+    async def test_async_invalid_uuid(self) -> None:
+        with self.assertRaises(ResultDoesNotExist):
+            await default_task_backend.aget_result("123")
+
+    def test_meaning_of_life_view(self) -> None:
+        for url in [
+            reverse("meaning-of-life"),
+            reverse("meaning-of-life-async"),
+        ]:
+            with self.subTest(url):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, 200)
+
+                data = json.loads(response.content)
+
+                self.assertEqual(data["result"], None)
+                self.assertEqual(data["status"], ResultStatus.NEW)
+
+                result = default_task_backend.get_result(data["result_id"])
+                self.assertEqual(result.status, ResultStatus.NEW)
+
+    def test_get_result_from_different_request(self) -> None:
+        response = self.client.get(reverse("meaning-of-life"))
+        self.assertEqual(response.status_code, 200)
+
+        data = json.loads(response.content)
+        result_id = data["result_id"]
+
+        response = self.client.get(reverse("result", args=[result_id]))
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(
+            json.loads(response.content),
+            {"result_id": result_id, "result": None, "status": ResultStatus.NEW},
+        )
+
+    def test_invalid_task_path(self) -> None:
+        job = django_rq.get_queue("default", job_class=Job).enqueue_call(
+            "subprocess.check_output", args=["exit", "1"]
+        )
+
+        with self.assertRaisesMessage(
+            SuspiciousOperation,
+            f"Task {job.id} does not point to a Task (subprocess.check_output)",
+        ):
+            default_task_backend.get_result(job.id)
+
+    def test_check(self) -> None:
+        errors = list(default_task_backend.check())
+
+        self.assertEqual(len(errors), 0, errors)
+
+    @override_settings(INSTALLED_APPS=[])
+    def test_rq_app_missing(self) -> None:
+        errors = list(default_task_backend.check())
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("django_rq", errors[0].hint)  # type:ignore[arg-type]
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.rq.RQBackend",
+                "ENQUEUE_ON_COMMIT": True,
+            }
+        }
+    )
+    def test_wait_until_transaction_commit(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        queue = django_rq.get_queue("default", job_class=Job)
+
+        with transaction.atomic():
+            result = test_tasks.noop_task.enqueue()
+
+            self.assertIsNone(result.enqueued_at)
+
+            self.assertEqual(queue.count, 0)
+        self.assertEqual(queue.count, 1)
+
+        result.refresh()
+        self.assertIsNotNone(result.enqueued_at)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.rq.RQBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_doesnt_wait_until_transaction_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertFalse(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+        queue = django_rq.get_queue("default", job_class=Job)
+
+        with transaction.atomic():
+            result = test_tasks.noop_task.enqueue()
+
+            self.assertIsNotNone(result.enqueued_at)
+
+            self.assertEqual(queue.count, 1)
+
+        self.assertEqual(queue.count, 1)
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.rq.RQBackend",
+            }
+        }
+    )
+    def test_wait_until_transaction_by_default(self) -> None:
+        self.assertTrue(default_task_backend.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
+        )
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.rq.RQBackend",
+                "ENQUEUE_ON_COMMIT": False,
+            }
+        }
+    )
+    def test_task_specific_enqueue_on_commit(self) -> None:
+        self.assertFalse(default_task_backend.enqueue_on_commit)
+        self.assertTrue(test_tasks.enqueue_on_commit_task.enqueue_on_commit)
+        self.assertTrue(
+            default_task_backend._get_enqueue_on_commit_for_task(
+                test_tasks.enqueue_on_commit_task
+            )
+        )
+
+    def test_enqueue_logs(self) -> None:
+        with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
+            result = test_tasks.noop_task.enqueue()
+
+        self.assertEqual(len(captured_logs.output), 1)
+        self.assertIn("enqueued", captured_logs.output[0])
+        self.assertIn(result.id, captured_logs.output[0])
+
+    def test_enqueue_priority(self) -> None:
+        task_1 = test_tasks.noop_task.enqueue()
+        task_2 = test_tasks.noop_task.using(priority=100).enqueue()
+
+        queue = django_rq.get_queue("default")
+
+        self.assertEqual(queue.job_ids, [task_2.id, task_1.id])
+
+        self.assertEqual(task_2.task.priority, 100)
+
+        self.assertEqual(default_task_backend.get_result(task_2.id).task.priority, 0)
+
+    def test_queue_isolation(self) -> None:
+        default_task = test_tasks.noop_task.enqueue()
+        other_task = test_tasks.noop_task.using(queue_name="queue-1").enqueue()
+
+        default_task_backend.get_result(default_task.id)
+        default_task_backend.get_result(other_task.id)
+
+        self.assertEqual(django_rq.get_queue("default").job_ids, [default_task.id])
+        self.assertEqual(django_rq.get_queue("queue-1").job_ids, [other_task.id])
+
+    @override_settings(
+        TASKS={
+            "default": {"BACKEND": "django_tasks.backends.rq.RQBackend", "QUEUES": []}
+        }
+    )
+    def test_uses_rq_queues_for_queue_names(self) -> None:
+        self.assertEqual(default_task_backend.queues, {"default", "queue-1"})
+
+    @override_settings(
+        TASKS={
+            "default": {
+                "BACKEND": "django_tasks.backends.rq.RQBackend",
+                "QUEUES": ["queue-2"],
+            }
+        }
+    )
+    def test_unknown_queue_name(self) -> None:
+        errors = list(default_task_backend.check())
+
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Add 'queue-2' to RQ_QUEUES", errors[0].hint)  # type:ignore[arg-type]

--- a/tests/tests/test_rq_backend.py
+++ b/tests/tests/test_rq_backend.py
@@ -11,6 +11,7 @@ from django.db import transaction
 from django.test import TransactionTestCase, modify_settings, override_settings
 from django.urls import reverse
 from fakeredis import FakeRedis, FakeStrictRedis
+from rq.timeouts import TimerDeathPenalty
 
 from django_tasks import ResultStatus, Task, default_task_backend, tasks
 from django_tasks.backends.rq import Job, RQBackend
@@ -77,6 +78,9 @@ class DatabaseBackendTestCase(TransactionTestCase):
 
         for queue in default_task_backend._get_queues():  # type: ignore[attr-defined]
             worker = SimpleWorker([queue], prepare_for_work=False, job_class=Job)
+
+            # Use timer death penalty to support Windows
+            worker.death_penalty_class = TimerDeathPenalty  # type: ignore[assignment]
 
             # HACK: Work around fakeredis not supporting `CLIENT LIST`
             worker.hostname = "example-hostname"


### PR DESCRIPTION
Add an RQ backend - a 3rd-party backend using the `django_tasks` API.

RQ supports almost all the `django_tasks` API, besides `priority`, which it doesn't have native support for.