### PR TITLE
Add started signal

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Whilst signals are available, they may not be the most maintainable approach.
 
 - `django_tasks.signals.task_enqueued`: Called when a task is enqueued. The sender is the backend class. Also called with the enqueued `task_result`.
 - `django_tasks.signals.task_finished`: Called when a task finishes (`SUCCEEDED` or `FAILED`). The sender is the backend class. Also called with the finished `task_result`.
+- `django_tasks.signals.task_started`: Called immediately before a task starts executing. The sender is the backend class. Also called with the started `task_result`.
 
 ## RQ
 

--- a/django_tasks/signal_handlers.py
+++ b/django_tasks/signal_handlers.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 
 from django_tasks import BaseTaskBackend, ResultStatus, TaskResult
 
-from .signals import task_enqueued, task_finished
+from .signals import task_enqueued, task_finished, task_started
 
 logger = logging.getLogger("django_tasks")
 
@@ -32,6 +32,18 @@ def log_task_enqueued(
         task_result.id,
         task_result.task.module_path,
         task_result.backend,
+    )
+
+
+@receiver(task_started)
+def log_task_started(
+    sender: type[BaseTaskBackend], task_result: TaskResult, **kwargs: dict
+) -> None:
+    logger.info(
+        "Task id=%s path=%s state=%s",
+        task_result.id,
+        task_result.task.module_path,
+        task_result.status,
     )
 
 

--- a/django_tasks/signals.py
+++ b/django_tasks/signals.py
@@ -2,3 +2,4 @@ from django.dispatch import Signal
 
 task_enqueued = Signal()
 task_finished = Signal()
+task_started = Signal()

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -220,8 +220,27 @@ class ImmediateBackendTestCase(SimpleTestCase):
         with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
             result = test_tasks.noop_task.enqueue()
 
+        self.assertEqual(len(captured_logs.output), 3)
+
         self.assertIn("enqueued", captured_logs.output[0])
         self.assertIn(result.id, captured_logs.output[0])
+
+        self.assertIn("state=RUNNING", captured_logs.output[1])
+        self.assertIn(result.id, captured_logs.output[1])
+
+        self.assertIn("state=SUCCEEDED", captured_logs.output[2])
+        self.assertIn(result.id, captured_logs.output[2])
+
+    def test_failed_logs(self) -> None:
+        with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
+            result = test_tasks.failing_task_value_error.enqueue()
+
+        self.assertEqual(len(captured_logs.output), 3)
+        self.assertIn("state=RUNNING", captured_logs.output[1])
+        self.assertIn(result.id, captured_logs.output[1])
+
+        self.assertIn("state=FAILED", captured_logs.output[2])
+        self.assertIn(result.id, captured_logs.output[2])
 
     def test_check(self) -> None:
         errors = list(default_task_backend.check())


### PR DESCRIPTION
Fixes #142 

Add a started signal, to hook in to when a task is about to start.

Only used internally for logging.