### PR TITLE
Terminate worker a little harder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
         run: just lint
       - name: Run fast tests
         if: ${{ !cancelled() }}
-        run: just test-fast
+        run: just test-fast -v2
       - name: Run tests
         if: ${{ !cancelled() }}
-        run: just test
+        run: just test -v2
 
   test-postgres:
     runs-on: ubuntu-latest
@@ -82,7 +82,7 @@ jobs:
           pip install -e '.[dev,postgres]'
           pip install Django~=${{ matrix.django-version }}
       - name: Run tests
-        run: just test
+        run: just test -v2
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost/postgres
 
@@ -117,7 +117,7 @@ jobs:
           pip install -e '.[dev,mysql]'
           pip install Django~=${{ matrix.django-version }}
       - name: Run tests
-        run: just test
+        run: just test -v2
         env:
           DATABASE_URL: mysql://root:django@127.0.0.1/django
 

--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -53,6 +53,7 @@ class Worker:
             logger.warning(
                 "Received %s - terminating current task.", signal.strsignal(signum)
             )
+            self.reset_signals()
             sys.exit(1)
 
         logger.warning(
@@ -71,6 +72,12 @@ class Worker:
         signal.signal(signal.SIGTERM, self.shutdown)
         if hasattr(signal, "SIGQUIT"):
             signal.signal(signal.SIGQUIT, self.shutdown)
+
+    def reset_signals(self) -> None:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        if hasattr(signal, "SIGQUIT"):
+            signal.signal(signal.SIGQUIT, signal.SIG_DFL)
 
     def start(self) -> None:
         logger.info("Starting worker for queues=%s", ",".join(self.queue_names))

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1295,7 +1295,7 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
             for process in self.processes:
                 if process.poll() is None:
                     process.kill()
-                    time.sleep(0.2)
+                    process.wait(1)
 
     def start_worker(
         self, args: Optional[List[str]] = None, debug: bool = False

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -1291,9 +1291,11 @@ class DatabaseWorkerProcessTestCase(TransactionTestCase):
 
     def tearDown(self) -> None:
         # Try n times to kill any remaining child processes
-        for _ in range(10):
+        for n in range(20):
             for process in self.processes:
                 if process.poll() is None:
+                    if n >= 5:
+                        print("Still waiting for process", process.pid, process.args)  # noqa: T201
                     process.kill()
                     process.wait(1)
 


### PR DESCRIPTION
There have been some non-deterministic CI failures, only on Windows, around the database still being in use after Django tries to delete the SQLite database.

This PR tries to resolve that, by:

- Waiting longer between terminate attempts in tests. This may slow down tests, but should be faster for processes which behave nicely.
- Reset worker signals when a task is uncleanly terminated. This lets Python take over with handling what to do with subsequent signals, and hopefully terminate the process harder :hammer:.