### PR TITLE
fix(db_worker): fix db_worker batch mode to exit when no more tasks 

### DIFF
--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -80,6 +80,7 @@ class Worker:
             time.sleep(random.random())
 
         while self.running:
+            task_result = None  # Ensure it's always defined
             tasks = DBTaskResult.objects.ready().filter(backend_name=self.backend_name)
             if not self.process_all_queues:
                 tasks = tasks.filter(queue_name__in=self.queue_names)


### PR DESCRIPTION
# Fix: Ensure db_worker Exits Correctly in Batch Mode
## Summary
This PR fixes an issue where the db_worker management command would not exit as expected when running with the` --batch` flag and no tasks were available. Previously, the worker kept running even without any more tasks to run.
## Changes
Initialize task_result = None at the start of each loop iteration in the Worker.start() method.
This guarantees that the batch mode exit condition (if self.batch and task_result is None) is always evaluated correctly, allowing the worker to exit gracefully when all tasks are processed.
## Impact
Batch mode (--batch): The worker now reliably exits when there are no more tasks to process.
Continuous mode (default): The worker continues to poll for new tasks as before; no change in behavior.

