### PR TITLE
Add support for receiving task context

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ def calculate_meaning_of_life(context: TaskContext) -> int:
 The task context has the following attributes:
 
 - `task_result`: The running task result
+- `attempt`: The current attempt number for the task
 
 This API will be extended with additional features in future.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ modified_task = calculate_meaning_of_life.using(priority=10)
 
 In addition to the above attributes, `run_after` can be passed to specify a specific time the task should run.
 
+#### Task context
+
+Sometimes the running task may need to know context about how it was enqueued. To receive the task context as an argument to your task function, pass `takes_context` to the decorator and ensure the task takes a `context` as the first argument.
+
+```python
+from django_tasks import task, TaskContext
+
+
+@task(takes_context=True)
+def calculate_meaning_of_life(context: TaskContext) -> int:
+    return 42
+```
+
+The task context has the following attributes:
+
+- `task_result`: The running task result
+
+This API will be extended with additional features in future.
+
 ### Enqueueing tasks
 
 To execute a task, call the `enqueue` method on it:

--- a/django_tasks/__init__.py
+++ b/django_tasks/__init__.py
@@ -16,6 +16,7 @@ from .task import (
     DEFAULT_TASK_BACKEND_ALIAS,
     ResultStatus,
     Task,
+    TaskContext,
     TaskResult,
     task,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "ResultStatus",
     "Task",
     "TaskResult",
+    "TaskContext",
 ]
 
 

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -239,37 +239,20 @@ def task(  # type: ignore[misc]
     """
     from . import tasks
 
-    if takes_context:
+    def wrapper(f: Callable[P, T]) -> Task[P, T]:
+        return tasks[backend].task_class(
+            priority=priority,
+            func=f,
+            queue_name=queue_name,
+            backend=backend,
+            enqueue_on_commit=enqueue_on_commit,
+            takes_context=takes_context,
+        )
 
-        def context_wrapper(
-            f: Callable[Concatenate["TaskContext", P], T],
-        ) -> Task[P, T]:
-            return tasks[backend].task_class(
-                priority=priority,
-                func=f,  # type: ignore[arg-type]
-                queue_name=queue_name,
-                backend=backend,
-                enqueue_on_commit=enqueue_on_commit,
-                takes_context=takes_context,
-            )
+    if function:
+        return wrapper(function)
 
-        return context_wrapper
-    else:
-
-        def wrapper(f: Callable[P, T]) -> Task[P, T]:
-            return tasks[backend].task_class(
-                priority=priority,
-                func=f,
-                queue_name=queue_name,
-                backend=backend,
-                enqueue_on_commit=enqueue_on_commit,
-                takes_context=takes_context,
-            )
-
-        if function:
-            return wrapper(function)
-
-        return wrapper
+    return wrapper
 
 
 @dataclass(frozen=True)

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     Generic,
+    Literal,
     Optional,
     TypeVar,
     Union,
@@ -17,7 +18,7 @@ from asgiref.sync import async_to_sync, sync_to_async
 from django.db.models.enums import TextChoices
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
-from typing_extensions import ParamSpec, Self
+from typing_extensions import Concatenate, ParamSpec, Self
 
 from .exceptions import ResultDoesNotExist
 from .utils import (
@@ -85,6 +86,11 @@ class Task(Generic[P, T]):
     """
     Whether the task will be enqueued when the current transaction commits,
     immediately, or whatever the backend decides
+    """
+
+    takes_context: bool = False
+    """
+    Whether the task receives the task context when executed.
     """
 
     def __post_init__(self) -> None:
@@ -197,36 +203,73 @@ def task(
     queue_name: str = DEFAULT_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
     enqueue_on_commit: Optional[bool] = None,
+    takes_context: Literal[False] = False,
 ) -> Callable[[Callable[P, T]], Task[P, T]]: ...
 
 
-# Implementation
+# Decorator with context and arguments
+# e.g. @task(takes_context=True, ...)
+@overload
 def task(
+    *,
+    priority: int = DEFAULT_PRIORITY,
+    queue_name: str = DEFAULT_QUEUE_NAME,
+    backend: str = DEFAULT_TASK_BACKEND_ALIAS,
+    enqueue_on_commit: Optional[bool] = None,
+    takes_context: Literal[True],
+) -> Callable[[Callable[Concatenate["TaskContext", P], T]], Task[P, T]]: ...
+
+
+# Implementation
+def task(  # type: ignore[misc]
     function: Optional[Callable[P, T]] = None,
     *,
     priority: int = DEFAULT_PRIORITY,
     queue_name: str = DEFAULT_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
     enqueue_on_commit: Optional[bool] = None,
-) -> Union[Task[P, T], Callable[[Callable[P, T]], Task[P, T]]]:
+    takes_context: bool = False,
+) -> Union[
+    Task[P, T],
+    Callable[[Callable[P, T]], Task[P, T]],
+    Callable[[Callable[Concatenate["TaskContext", P], T]], Task[P, T]],
+]:
     """
     A decorator used to create a task.
     """
     from . import tasks
 
-    def wrapper(f: Callable[P, T]) -> Task[P, T]:
-        return tasks[backend].task_class(
-            priority=priority,
-            func=f,
-            queue_name=queue_name,
-            backend=backend,
-            enqueue_on_commit=enqueue_on_commit,
-        )
+    if takes_context:
 
-    if function:
-        return wrapper(function)
+        def context_wrapper(
+            f: Callable[Concatenate["TaskContext", P], T],
+        ) -> Task[P, T]:
+            return tasks[backend].task_class(
+                priority=priority,
+                func=f,  # type: ignore[arg-type]
+                queue_name=queue_name,
+                backend=backend,
+                enqueue_on_commit=enqueue_on_commit,
+                takes_context=takes_context,
+            )
 
-    return wrapper
+        return context_wrapper
+    else:
+
+        def wrapper(f: Callable[P, T]) -> Task[P, T]:
+            return tasks[backend].task_class(
+                priority=priority,
+                func=f,
+                queue_name=queue_name,
+                backend=backend,
+                enqueue_on_commit=enqueue_on_commit,
+                takes_context=takes_context,
+            )
+
+        if function:
+            return wrapper(function)
+
+        return wrapper
 
 
 @dataclass(frozen=True)
@@ -330,3 +373,8 @@ class TaskResult(Generic[T]):
 
         for attr in TASK_REFRESH_ATTRS:
             object.__setattr__(self, attr, getattr(refreshed_task, attr))
+
+
+@dataclass(frozen=True)
+class TaskContext:
+    task_result: TaskResult

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -364,4 +364,4 @@ class TaskContext:
 
     @property
     def attempt(self) -> int:
-        return self.task_result.attempts + 1
+        return self.task_result.attempts

--- a/django_tasks/task.py
+++ b/django_tasks/task.py
@@ -361,3 +361,7 @@ class TaskResult(Generic[T]):
 @dataclass(frozen=True)
 class TaskContext:
     task_result: TaskResult
+
+    @property
+    def attempt(self) -> int:
+        return self.task_result.attempts + 1

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,7 +1,7 @@
 import time
 from typing import Any
 
-from django_tasks import task
+from django_tasks import TaskContext, task
 
 
 @task()
@@ -70,3 +70,8 @@ def hang() -> None:
 @task()
 def sleep_for(seconds: float) -> None:
     time.sleep(seconds)
+
+
+@task(takes_context=True)
+def get_task_id(context: TaskContext) -> str:
+    return context.task_result.id

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -75,3 +75,9 @@ def sleep_for(seconds: float) -> None:
 @task(takes_context=True)
 def get_task_id(context: TaskContext) -> str:
     return context.task_result.id
+
+
+@task(takes_context=True)
+def test_context(context: TaskContext, attempt: int) -> None:
+    assert isinstance(context, TaskContext)
+    assert context.attempt == attempt

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -862,6 +862,15 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
         self.assertEqual(statuses[ResultStatus.SUCCEEDED], 2)
         self.assertEqual(statuses[ResultStatus.READY], 3)
 
+    def test_takes_context(self) -> None:
+        result = test_tasks.get_task_id.enqueue()
+
+        self.run_worker()
+
+        result.refresh()
+
+        self.assertEqual(result.return_value, result.id)
+
 
 @override_settings(
     TASKS={

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -871,6 +871,14 @@ class DatabaseBackendWorkerTestCase(TransactionTestCase):
 
         self.assertEqual(result.return_value, result.id)
 
+    def test_context(self) -> None:
+        result = test_tasks.test_context.enqueue(1)
+
+        self.run_worker()
+        result.refresh()
+
+        self.assertEqual(result.status, ResultStatus.SUCCEEDED)
+
 
 @override_settings(
     TASKS={

--- a/tests/tests/test_dummy_backend.py
+++ b/tests/tests/test_dummy_backend.py
@@ -197,7 +197,7 @@ class DummyBackendTestCase(SimpleTestCase):
 
     def test_takes_context(self) -> None:
         result = test_tasks.get_task_id.enqueue()
-        self.assertEqual(result.status, ResultStatus.NEW)
+        self.assertEqual(result.status, ResultStatus.READY)
 
 
 class DummyBackendTransactionTestCase(TransactionTestCase):

--- a/tests/tests/test_dummy_backend.py
+++ b/tests/tests/test_dummy_backend.py
@@ -195,6 +195,10 @@ class DummyBackendTestCase(SimpleTestCase):
         self.assertEqual(len(errors), 1)
         self.assertIn("Set `ENQUEUE_ON_COMMIT` to False", errors[0].hint)  # type:ignore[arg-type]
 
+    def test_takes_context(self) -> None:
+        result = test_tasks.get_task_id.enqueue()
+        self.assertEqual(result.status, ResultStatus.NEW)
+
 
 class DummyBackendTransactionTestCase(TransactionTestCase):
     @override_settings(

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -257,6 +257,11 @@ class ImmediateBackendTestCase(SimpleTestCase):
 
         self.assertEqual(len(errors), 0, errors)
 
+    def test_takes_context(self) -> None:
+        result = test_tasks.get_task_id.enqueue()
+
+        self.assertEqual(result.return_value, result.id)
+
 
 class ImmediateBackendTransactionTestCase(TransactionTestCase):
     @override_settings(

--- a/tests/tests/test_immediate_backend.py
+++ b/tests/tests/test_immediate_backend.py
@@ -262,6 +262,10 @@ class ImmediateBackendTestCase(SimpleTestCase):
 
         self.assertEqual(result.return_value, result.id)
 
+    def test_context(self) -> None:
+        result = test_tasks.test_context.enqueue(1)
+        self.assertEqual(result.status, ResultStatus.SUCCEEDED)
+
 
 class ImmediateBackendTransactionTestCase(TransactionTestCase):
     @override_settings(

--- a/tests/tests/test_rq_backend.py
+++ b/tests/tests/test_rq_backend.py
@@ -500,3 +500,9 @@ class DatabaseBackendTestCase(TransactionTestCase):
         result.refresh()
 
         self.assertEqual(result.return_value, result.id)
+
+    def test_context(self) -> None:
+        result = test_tasks.test_context.enqueue(1)
+        self.run_worker()
+        result.refresh()
+        self.assertEqual(result.status, ResultStatus.SUCCEEDED)

--- a/tests/tests/test_rq_backend.py
+++ b/tests/tests/test_rq_backend.py
@@ -491,3 +491,12 @@ class DatabaseBackendTestCase(TransactionTestCase):
 
         self.assertEqual(len(errors), 1)
         self.assertIn("Add 'queue-2' to RQ_QUEUES", errors[0].hint)  # type:ignore[arg-type]
+
+    def test_takes_context(self) -> None:
+        result = test_tasks.get_task_id.enqueue()
+
+        self.run_worker()
+
+        result.refresh()
+
+        self.assertEqual(result.return_value, result.id)

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -299,3 +299,10 @@ class TaskTestCase(SimpleTestCase):
 
         with self.assertRaises(ImportError):
             immediate_task.errors[0].exception_class  # noqa: B018
+
+    def test_takes_context_without_taking_context(self) -> None:
+        with self.assertRaisesMessage(
+            InvalidTaskError,
+            "Task takes context but does not have a first argument of 'context'",
+        ):
+            task(takes_context=True)(test_tasks.calculate_meaning_of_life.func)  # type: ignore[arg-type]


### PR DESCRIPTION
Add support for receiving task context, which in future will enable tasks to understand more about how, when and where they're being run.