### PR TITLE
Allow disabling auto-reload for db_worker when settings.DEBUG is True

### DIFF
--- a/django_tasks/backends/database/management/commands/db_worker.py
+++ b/django_tasks/backends/database/management/commands/db_worker.py
@@ -5,7 +5,7 @@ import random
 import signal
 import sys
 import time
-from argparse import ArgumentParser, ArgumentTypeError
+from argparse import ArgumentParser, ArgumentTypeError, BooleanOptionalAction
 from types import FrameType
 from typing import Optional
 
@@ -224,7 +224,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--reload",
-            action="store_true",
+            action=BooleanOptionalAction,
             default=settings.DEBUG,
             help="Reload the worker on code changes. Not recommended for production as tasks may not be stopped cleanly (default: DEBUG)",
         )


### PR DESCRIPTION
The combination of "store_true" and setting a default made it impossible to disable the auto-reloading if the default (settings.DEBUG) is true.

Using BooleanOptionalAction a '--no-reload' flag is added.

Best regards,
Jan