### PR TITLE
restore implicit support for USE_TZ=False

### DIFF
--- a/django_tasks/backends/database/migrations/0016_remove_dbtaskresult_django_task_new_ordering_idx_and_more.py
+++ b/django_tasks/backends/database/migrations/0016_remove_dbtaskresult_django_task_new_ordering_idx_and_more.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+from django.conf import settings
 from django.db import migrations, models
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.migrations.state import StateApps
@@ -55,7 +56,12 @@ class Migration(migrations.Migration):
             name="run_after",
             field=models.DateTimeField(
                 default=datetime.datetime(
-                    9999, 1, 1, 0, 0, tzinfo=datetime.timezone.utc
+                    9999,
+                    1,
+                    1,
+                    0,
+                    0,
+                    tzinfo=datetime.timezone.utc if settings.USE_TZ else None,
                 ),
                 verbose_name="run after",
             ),

--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -4,6 +4,7 @@ import uuid
 from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar
 
 import django
+from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.db import models
 from django.db.models import F, Q
@@ -48,7 +49,9 @@ else:
             return cls
 
 
-DATE_MAX = datetime.datetime(9999, 1, 1, tzinfo=datetime.timezone.utc)
+DATE_MAX = datetime.datetime(
+    9999, 1, 1, tzinfo=datetime.timezone.utc if settings.USE_TZ else None
+)
 
 
 class DBTaskResultQuerySet(models.QuerySet):


### PR DESCRIPTION
Hello,

Before #155 setups with USE_TZ=False were implicitly supported. Since DATE_MAX is explicitly defined as a timezone aware datetime this broke setups with USE_TZ=False as

"SQLite backend does not support timezone-aware datetimes when USE_TZ is False."

Don't set tzdata in DATE_MAX when USE_TZ=False to fix this regression.


I'm aware that this is not a perfect solution. However, USE_TZ=False is supported by Django and we cannot easily enable it on our codebase.

Kind regards,
Jan