### PR TITLE
fix: prevent `IndexError: pop from empty list` in RQ backend

### DIFF
--- a/django_tasks/backends/rq.py
+++ b/django_tasks/backends/rq.py
@@ -124,7 +124,11 @@ class Job(BaseJob):
             if rq_result.type == Result.Type.FAILED:
                 task_result.errors.append(
                     TaskError(
-                        exception_class_path=exception_classes.pop(),
+                        exception_class_path=(
+                            exception_classes.pop()
+                            if len(exception_classes) > 0
+                            else get_module_path(Exception)
+                        ),
                         traceback=rq_result.exc_string,  # type: ignore[arg-type]
                     )
                 )


### PR DESCRIPTION
In the RQ backend, if the `_django_tasks_exceptions` metadata key is missing or empty, but the job has failed in the past, the `Job.task_result` would throw this exception:

```
IndexError: pop from empty list
  File "rq/job.py", line 1507, in execute_failure_callback
    self.failure_callback(self, self.connection, *exc_info)
  File "django_tasks/backends/rq.py", line 154, in failed_callback
    task_result = job.task_result
  File "django/utils/functional.py", line 47, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "django_tasks/backends/rq.py", line 127, in task_result
    exception_class_path=exception_classes.pop(),
```

Then, since `Job.task_result` is accessed in `Job.perform`, this exception would prevent any further jobs from being queued. This commit handles the case of an empty or missing _django_tasks_exceptions metadata key by substituting in `builtins.Exception` for the missing exception class path.