### PR TITLE
Remove `enqueue_on_commit` functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,6 @@ The task decorator accepts a few arguments to customize the task:
 - `priority`: The priority of the task (between -100 and 100. Larger numbers are higher priority. 0 by default)
 - `queue_name`: Whether to run the task on a specific queue
 - `backend`: Name of the backend for this task to use (as defined in `TASKS`)
-- `enqueue_on_commit`: Whether the task is enqueued when the current transaction commits successfully, or enqueued immediately. By default, this is handled by the backend (see below). `enqueue_on_commit` may not be modified with `.using`.
-
-These attributes (besides `enqueue_on_commit`) can also be modified at run-time with `.using`:
 
 ```python
 modified_task = calculate_meaning_of_life.using(priority=10)
@@ -107,23 +104,6 @@ result = calculate_meaning_of_life.enqueue()
 The returned `TaskResult` can be interrogated to query the current state of the running task, as well as its return value.
 
 If the task takes arguments, these can be passed as-is to `enqueue`.
-
-#### Transactions
-
-By default, tasks are enqueued after the current transaction (if there is one) commits successfully (using Django's `transaction.on_commit` method), rather than enqueueing immediately.
-
-This can be configured using the `ENQUEUE_ON_COMMIT` setting. `True` and `False` force the behaviour.
-
-```python
-TASKS = {
-    "default": {
-        "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-        "ENQUEUE_ON_COMMIT": False
-    }
-}
-```
-
-This can also be configured per-task by passing `enqueue_on_commit` to the `task` decorator.
 
 ### Queue names
 

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -1,8 +1,6 @@
 import logging
-from functools import partial
 from typing import TypeVar
 
-from django.db import transaction
 from django.utils import timezone
 from typing_extensions import ParamSpec
 
@@ -110,9 +108,6 @@ class ImmediateBackend(BaseTaskBackend):
             worker_ids=[],
         )
 
-        if self._get_enqueue_on_commit_for_task(task) is not False:
-            transaction.on_commit(partial(self._execute_task, task_result))
-        else:
-            self._execute_task(task_result)
+        self._execute_task(task_result)
 
         return task_result

--- a/django_tasks/base.py
+++ b/django_tasks/base.py
@@ -82,12 +82,6 @@ class Task(Generic[P, T]):
     run_after: datetime | None
     """The earliest this Task will run"""
 
-    enqueue_on_commit: bool | None
-    """
-    Whether the Task will be enqueued when the current transaction commits,
-    immediately, or whatever the backend decides.
-    """
-
     takes_context: bool
     """
     Whether the Task receives the Task context when executed.
@@ -199,7 +193,6 @@ def task(
     priority: int = TASK_DEFAULT_PRIORITY,
     queue_name: str = DEFAULT_TASK_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
-    enqueue_on_commit: bool | None = None,
     takes_context: Literal[False] = False,
 ) -> Callable[[Callable[P, T]], Task[P, T]]: ...
 
@@ -212,7 +205,6 @@ def task(
     priority: int = TASK_DEFAULT_PRIORITY,
     queue_name: str = DEFAULT_TASK_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
-    enqueue_on_commit: bool | None = None,
     takes_context: Literal[True],
 ) -> Callable[[Callable[Concatenate["TaskContext", P], T]], Task[P, T]]: ...
 
@@ -224,7 +216,6 @@ def task(  # type: ignore[misc]
     priority: int = TASK_DEFAULT_PRIORITY,
     queue_name: str = DEFAULT_TASK_QUEUE_NAME,
     backend: str = DEFAULT_TASK_BACKEND_ALIAS,
-    enqueue_on_commit: bool | None = None,
     takes_context: bool = False,
 ) -> (
     Task[P, T]
@@ -242,7 +233,6 @@ def task(  # type: ignore[misc]
             func=f,
             queue_name=queue_name,
             backend=backend,
-            enqueue_on_commit=enqueue_on_commit,
             takes_context=takes_context,
             run_after=None,
         )

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -55,16 +55,6 @@ def exit_task() -> None:
     exit(1)
 
 
-@task(enqueue_on_commit=True)
-def enqueue_on_commit_task() -> None:
-    pass
-
-
-@task(enqueue_on_commit=False)
-def never_enqueue_on_commit_task() -> None:
-    pass
-
-
 @task()
 def hang() -> None:
     """

--- a/tests/tests/test_custom_backend.py
+++ b/tests/tests/test_custom_backend.py
@@ -30,7 +30,6 @@ class CustomBackendNoEnqueue(BaseTaskBackend):
     TASKS={
         "default": {
             "BACKEND": get_module_path(CustomBackend),
-            "ENQUEUE_ON_COMMIT": False,
             "OPTIONS": {"prefix": "PREFIX: "},
         },
         "no_enqueue": {

--- a/tests/tests/test_database_backend.py
+++ b/tests/tests/test_database_backend.py
@@ -322,45 +322,10 @@ class DatabaseBackendTestCase(TransactionTestCase):
         TASKS={
             "default": {
                 "BACKEND": "django_tasks.backends.database.DatabaseBackend",
-                "ENQUEUE_ON_COMMIT": True,
-            }
-        }
-    )
-    def test_wait_until_transaction_commit(self) -> None:
-        self.assertTrue(default_task_backend.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
-        with transaction.atomic():
-            result = test_tasks.noop_task.enqueue()
-
-            self.assertIsNone(result.enqueued_at)
-
-            self.assertEqual(DBTaskResult.objects.count(), 0)
-            # SQLite locks the table during this transaction
-            if connection.vendor != "sqlite":
-                self.assertEqual(self.get_task_count_in_new_connection(), 0)
-
-        if connection.vendor != "sqlite":
-            self.assertEqual(self.get_task_count_in_new_connection(), 1)
-        result.refresh()
-        self.assertIsNotNone(result.enqueued_at)
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.database.DatabaseBackend",
-                "ENQUEUE_ON_COMMIT": False,
             }
         }
     )
     def test_doesnt_wait_until_transaction_commit(self) -> None:
-        self.assertFalse(default_task_backend.enqueue_on_commit)
-        self.assertFalse(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
         with transaction.atomic():
             result = test_tasks.noop_task.enqueue()
 
@@ -374,36 +339,6 @@ class DatabaseBackendTestCase(TransactionTestCase):
 
         if connection.vendor != "sqlite":
             self.assertEqual(self.get_task_count_in_new_connection(), 1)
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.database.DatabaseBackend",
-            }
-        }
-    )
-    def test_wait_until_transaction_by_default(self) -> None:
-        self.assertTrue(default_task_backend.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.database.DatabaseBackend",
-                "ENQUEUE_ON_COMMIT": False,
-            }
-        }
-    )
-    def test_task_specific_enqueue_on_commit(self) -> None:
-        self.assertFalse(default_task_backend.enqueue_on_commit)
-        self.assertTrue(test_tasks.enqueue_on_commit_task.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(
-                test_tasks.enqueue_on_commit_task
-            )
-        )
 
     def test_enqueue_logs(self) -> None:
         with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
@@ -484,7 +419,6 @@ class DatabaseBackendTestCase(TransactionTestCase):
                 "default": {
                     "BACKEND": "django_tasks.backends.rq.RQBackend",
                     "QUEUES": ["unknown_queue"],
-                    "ENQUEUE_ON_COMMIT": False,
                 }
             }
         ):
@@ -503,7 +437,6 @@ class DatabaseBackendTestCase(TransactionTestCase):
                 "default": {
                     "BACKEND": "django_tasks.backends.rq.RQBackend",
                     "QUEUES": ["unknown_queue"],
-                    "ENQUEUE_ON_COMMIT": False,
                 }
             }
         ):

--- a/tests/tests/test_rq_backend.py
+++ b/tests/tests/test_rq_backend.py
@@ -357,43 +357,10 @@ class RQBackendTestCase(TransactionTestCase):
         TASKS={
             "default": {
                 "BACKEND": "django_tasks.backends.rq.RQBackend",
-                "ENQUEUE_ON_COMMIT": True,
-            }
-        }
-    )
-    def test_wait_until_transaction_commit(self) -> None:
-        self.assertTrue(default_task_backend.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
-        queue = django_rq.get_queue("default", job_class=Job)
-
-        with transaction.atomic():
-            result = test_tasks.noop_task.enqueue()
-
-            self.assertIsNone(result.enqueued_at)
-
-            self.assertEqual(queue.count, 0)
-        self.assertEqual(queue.count, 1)
-
-        result.refresh()
-        self.assertIsNotNone(result.enqueued_at)
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.rq.RQBackend",
-                "ENQUEUE_ON_COMMIT": False,
             }
         }
     )
     def test_doesnt_wait_until_transaction_commit(self) -> None:
-        self.assertFalse(default_task_backend.enqueue_on_commit)
-        self.assertFalse(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
         queue = django_rq.get_queue("default", job_class=Job)
 
         with transaction.atomic():
@@ -404,36 +371,6 @@ class RQBackendTestCase(TransactionTestCase):
             self.assertEqual(queue.count, 1)
 
         self.assertEqual(queue.count, 1)
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.rq.RQBackend",
-            }
-        }
-    )
-    def test_wait_until_transaction_by_default(self) -> None:
-        self.assertTrue(default_task_backend.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(test_tasks.noop_task)
-        )
-
-    @override_settings(
-        TASKS={
-            "default": {
-                "BACKEND": "django_tasks.backends.rq.RQBackend",
-                "ENQUEUE_ON_COMMIT": False,
-            }
-        }
-    )
-    def test_task_specific_enqueue_on_commit(self) -> None:
-        self.assertFalse(default_task_backend.enqueue_on_commit)
-        self.assertTrue(test_tasks.enqueue_on_commit_task.enqueue_on_commit)
-        self.assertTrue(
-            default_task_backend._get_enqueue_on_commit_for_task(
-                test_tasks.enqueue_on_commit_task
-            )
-        )
 
     def test_enqueue_logs(self) -> None:
         with self.assertLogs("django_tasks", level="DEBUG") as captured_logs:
@@ -567,7 +504,6 @@ class RQBackendTestCase(TransactionTestCase):
                 "default": {
                     "BACKEND": "django_tasks.backends.rq.RQBackend",
                     "QUEUES": ["unknown_queue"],
-                    "ENQUEUE_ON_COMMIT": False,
                 }
             }
         ):
@@ -586,7 +522,6 @@ class RQBackendTestCase(TransactionTestCase):
                 "default": {
                     "BACKEND": "django_tasks.backends.rq.RQBackend",
                     "QUEUES": ["unknown_queue"],
-                    "ENQUEUE_ON_COMMIT": False,
                 }
             }
         ):

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -29,11 +29,9 @@ from tests import tasks as test_tasks
         "default": {
             "BACKEND": "django_tasks.backends.dummy.DummyBackend",
             "QUEUES": ["default", "queue_1"],
-            "ENQUEUE_ON_COMMIT": False,
         },
         "immediate": {
             "BACKEND": "django_tasks.backends.immediate.ImmediateBackend",
-            "ENQUEUE_ON_COMMIT": False,
             "QUEUES": [],
         },
         "missing": {"BACKEND": "does.not.exist"},


### PR DESCRIPTION
Fixes #189, #208

The behaviour is complex enough internally, but simple to do externally for those who need it.

This matches the upstream position. If it comes back, it needs more thought.