### PR TITLE
Drop support for Django 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["4.2", "5.0", "5.1", "5.2", "6.0b1"]
+        django-version: ["4.2", "5.1", "5.2", "6.0b1"]
         exclude:
           - django-version: "6.0b1"
             python-version: "3.10"
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0", "5.1", "5.2"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           - django-version: "4.2"
     steps:
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        django-version: ["4.2", "5.0", "5.1", "5.2"]
+        django-version: ["4.2", "5.1", "5.2"]
         exclude:
           - django-version: "4.2"
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django",
     "Framework :: Django :: 4.2",
-    "Framework :: Django :: 5.0",
     "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",


### PR DESCRIPTION
Extended/security support for version 5.0 ended in April 2025.

https://www.djangoproject.com/download/
https://endoflife.date/django
