### PR TITLE
migrate development optional- dependencies to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -e '.[dev]'
+          pip install -e . --group dev
           pip install Django~=${{ matrix.django-version }}
       - name: Lint
         run: just lint
@@ -83,7 +83,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -e '.[dev,postgres]'
+          pip install -e . --group dev --group postgres
           pip install Django~=${{ matrix.django-version }}
       - name: Run tests
         run: just test -v2
@@ -120,7 +120,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install -e '.[dev,mysql]'
+          pip install -e . --group dev --group mysql
           pip install Django~=${{ matrix.django-version }}
       - name: Run tests
         run: just test -v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,11 +17,11 @@ Set up a venv:
 ```sh
 python -m venv .venv
 source .venv/bin/activate
-python -m pip install -e '.[dev]'
+python -m pip install -e --group dev
 ```
 
 > [!TIP]
-> Add an extra name for each database you want to develop with (e.g. `[dev,mysql]`,  `[dev,postgres]` or `[dev,mysql,postgres]`). This is optional.
+> To include support for a specific database, you can stack group flags (e.g. `--group dev --group postgres`). This is optional.
 
 Then you can run the tests with the [just](https://just.systems/man/en/) command runner:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,13 @@ Issues = "https://github.com/RealOrangeOne/django-tasks/issues"
 Changelog = "https://github.com/RealOrangeOne/django-tasks/releases"
 
 [project.optional-dependencies]
+rq = [
+    "django-rq",
+    "rq>=2.5",
+    "rq_scheduler",
+]
+
+[dependency-groups]
 dev = [
     "ruff",
     "coverage",
@@ -63,11 +70,6 @@ mysql = [
 ]
 postgres = [
     "psycopg[binary]",
-]
-rq = [
-    "django-rq",
-    "rq>=2.5",
-    "rq_scheduler",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
This PR migrates our development, testing, and database-specific dependencies from `project.optional-dependencies `(extras) to the new [PEP 735](https://peps.python.org/pep-0735/) `dependency-groups` standard.

Why?
- Standardization: Adopts the official Python way to manage non-runtime dependencies.
- Leaner Packages: Dependency groups are strictly for development/CI and are not included in the built distribution (wheel) metadata, keeping the package clean for end-users.
- Logical Separation: Clearly distinguishes between "features" (extras) and "tooling" (groups).

Changes
- Moved dev, mysql, postgres, and rq requirements to the [dependency-groups] table in `pyproject.toml.`
- Updated local installation documentation to use the --group flag.