### PR TITLE
Fix runtime instantiation of TaskResult[T] on Python 3.11

### DIFF
--- a/django_tasks/backends/database/models.py
+++ b/django_tasks/backends/database/models.py
@@ -179,7 +179,7 @@ class DBTaskResult(GenericBase[P, T], models.Model):
     def task_result(self) -> "TaskResult[T]":
         from .backend import TaskResult
 
-        task_result = TaskResult[T](
+        task_result: TaskResult[T] = TaskResult(
             db_result=self,
             task=self.task,
             id=normalize_uuid(self.id),

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -34,7 +34,7 @@ class DummyBackend(BaseTaskBackend):
     ) -> TaskResult[T]:
         self.validate_task(task)
 
-        result = TaskResult[T](
+        result: TaskResult[T] = TaskResult(
             task=task,
             id=get_random_id(),
             status=TaskResultStatus.READY,

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -93,7 +93,7 @@ class ImmediateBackend(BaseTaskBackend):
     ) -> TaskResult[T]:
         self.validate_task(task)
 
-        task_result = TaskResult[T](
+        task_result: TaskResult[T] = TaskResult(
             task=task,
             id=get_random_id(),
             status=TaskResultStatus.READY,

--- a/django_tasks/backends/rq.py
+++ b/django_tasks/backends/rq.py
@@ -220,7 +220,7 @@ class RQBackend(BaseTaskBackend):
 
         metadata = {"_django_tasks_backend_name": self.alias}
 
-        task_result = TaskResult[T](
+        task_result: TaskResult[T] = TaskResult(
             task=task,
             id=get_random_id(),
             status=TaskResultStatus.READY,


### PR DESCRIPTION
This PR fixes a runtime `TypeError` on early version of Python 3.11 and Python 3.12 caused by instantiating
parameterized generics (`TaskResult[T]`) at runtime.

#### What changed
- Replace all runtime `TaskResult[…](…)` calls with plain `TaskResult(…)`
- Add explicit local variable annotations (`task_result: TaskResult[T]`)
  to preserve static typing
- No public API or behavior changes

#### Why
On Python 3.11.x and 3.12.x, instantiating a parameterized generic causes `typing` to assign
`__orig_class__` to the instance, which fails due to `TaskResult`’s restricted
`__setattr__`, raising a `TypeError`.

This approach avoids the runtime typing machinery while keeping full type safety.

#### Notes
- All linting and tests pass
- Static typing is unchanged
- Runtime behavior is identical except for avoiding the crash

Fixes #223 and #202 
Fixes the underlying cause of wagtail/wagtail#13589
