### PR TITLE
Add feature for metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ The task context has the following attributes:
 
 - `task_result`: The running task result
 - `attempt`: The current attempt number for the task
-- `metadata`: A `dict` which can be used to write arbitrary [metadata](#metadata). Keys starting `_django_tasks` should be reserved for backend implementations.
+- `metadata`: A `dict` which can be used to write arbitrary [metadata](#metadata). If a backend doesn't support metadata, this dictionary will always be empty. Keys starting `_django_tasks` should be reserved for backend implementations. 
 
 And the following methods:
 
-- `save_metadata` (and `asave_metadata`): Save any modifications to `metadata` to the queue.
+- `save_metadata` (and `asave_metadata`): Save any modifications to `metadata` to the queue. If the backend does not support metadata, this method will raise an exception.
 
 This API will be extended with additional features in future.
 
@@ -252,7 +252,7 @@ Attached to a task result is "metadata". This metadata can be used as a space to
 
 During a task, metadata can be accessed from `context.metadata`, and `result.metadata` from retrieved results.
 
-Metadata is saved when a task is finished, regardless of whether it succeeded or failed. Additionally, metadata can be saved manually using `context.save_metadata`.
+Metadata is saved when a task is finished, regardless of whether it succeeded or failed. Additionally, metadata can be saved manually using `context.save_metadata`. If a backend doesn't support metadata, this method will raise an exception.
 
 ### Backend introspecting
 
@@ -262,6 +262,7 @@ Because `django-tasks` enables support for multiple different backends, those ba
 - `supports_async_task`: Can coroutines be enqueued?
 - `supports_get_result`: Can results be retrieved after the fact (from **any** thread / process)?
 - `supports_priority`: Can tasks be executed in a given priority order?
+- `supports_metadata`: Can metadata be stored against a task result?
 
 ```python
 from django_tasks import default_task_backend

--- a/django_tasks/backends/base.py
+++ b/django_tasks/backends/base.py
@@ -41,6 +41,9 @@ class BaseTaskBackend(metaclass=ABCMeta):
     supports_priority = False
     """Does the backend support tasks being executed in a given priority order?"""
 
+    supports_metadata = False
+    """Does the backend support storing metadata against a task result?"""
+
     def __init__(self, alias: str, params: dict) -> None:
         from django_tasks import DEFAULT_TASK_QUEUE_NAME
 
@@ -138,9 +141,9 @@ class BaseTaskBackend(metaclass=ABCMeta):
     def check(self, **kwargs: Any) -> Iterable[checks.CheckMessage]:
         return []
 
-    @abstractmethod
     def save_metadata(self, result_id: str, metadata: dict[str, Any]) -> None:
         """Save metadata"""
+        raise NotImplementedError("This backend does not support saving metadata")
 
     async def asave_metadata(self, result_id: str, metadata: dict[str, Any]) -> None:
         """Save metadata"""

--- a/django_tasks/backends/database/backend.py
+++ b/django_tasks/backends/database/backend.py
@@ -35,6 +35,7 @@ class DatabaseBackend(BaseTaskBackend):
     supports_get_result = True
     supports_defer = True
     supports_priority = True
+    supports_metadata = True
 
     def __init__(self, alias: str, params: dict) -> None:
         from .models import DBTaskResult

--- a/django_tasks/backends/dummy.py
+++ b/django_tasks/backends/dummy.py
@@ -19,6 +19,7 @@ class DummyBackend(BaseTaskBackend):
     supports_defer = True
     supports_async_task = True
     supports_priority = True
+    supports_metadata = True
     results: list[TaskResult]
 
     def __init__(self, alias: str, params: dict) -> None:

--- a/django_tasks/backends/immediate.py
+++ b/django_tasks/backends/immediate.py
@@ -25,6 +25,7 @@ P = ParamSpec("P")
 class ImmediateBackend(BaseTaskBackend):
     supports_async_task = True
     supports_priority = True
+    supports_metadata = True
 
     def __init__(self, alias: str, params: dict):
         super().__init__(alias, params)

--- a/django_tasks/backends/rq.py
+++ b/django_tasks/backends/rq.py
@@ -203,6 +203,7 @@ class RQBackend(BaseTaskBackend):
     supports_async_task = True
     supports_get_result = True
     supports_defer = True
+    supports_metadata = True
 
     def __init__(self, alias: str, params: dict) -> None:
         super().__init__(alias, params)


### PR DESCRIPTION
This allow backends to declare whether they support metadata (#212 ). Most task queues I could find supported some kind of metadata, but some may not (or not quite in the way we need it). This therefore makes support opt-in (and opts in all the first-party backends).