### PR TITLE
Dropped support for Django 5.0 and Django 5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.0", "5.1", "5.2", "6.0"]
+        django-version: ["5.2", "6.0"]
         exclude:
           - django-version: "6.0"
             python-version: "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Django",
     "Framework :: Django",
-    "Framework :: Django :: 5.0",
-    "Framework :: Django :: 5.1",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
@@ -38,7 +36,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "Django>=5.0",
+    "Django>=5.2",
     "typing_extensions",
     "django-stubs-ext",
 ]


### PR DESCRIPTION
see https://www.djangoproject.com/download/

django 5.0 and django 5.1 already EOL in 2025. 