### PR TITLE
Allow `Task` and `TaskResult` to be pickled

### DIFF
--- a/django_tasks/base.py
+++ b/django_tasks/base.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime
 from inspect import isclass, iscoroutinefunction
 from typing import (
@@ -89,6 +89,23 @@ class Task(Generic[P, T]):
 
     def __post_init__(self) -> None:
         self.get_backend().validate_task(self)
+
+    @classmethod
+    def _reconstruct(cls, kwargs: dict) -> Self:
+        func_path = kwargs["func"]
+        try:
+            func = import_string(func_path)
+            kwargs["func"] = func.func
+        except (ImportError, AttributeError) as e:
+            msg = f"Expected {func_path!r} to point to a Task instance."
+            raise ValueError(msg) from e
+        return cls(**kwargs)
+
+    def __reduce__(self) -> tuple:
+        kwargs = {f.name: getattr(self, f.name) for f in fields(self)}
+        kwargs["func"] = self.module_path
+
+        return (self.__class__._reconstruct, (kwargs,))
 
     @property
     def name(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "W", "N", "B", "A", "C4", "T20", "DJ", "S", "UP"]
-ignore = ["E501", "DJ008"]
+ignore = ["E501", "DJ008", "S301"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/db_worker_test_settings.py" = ["F403", "F405"]

--- a/tests/tests/test_tasks.py
+++ b/tests/tests/test_tasks.py
@@ -1,4 +1,5 @@
 import dataclasses
+import pickle
 from datetime import datetime
 
 from django.test import SimpleTestCase, override_settings
@@ -268,6 +269,31 @@ class TaskTestCase(SimpleTestCase):
             import_string(test_tasks.noop_task_async.module_path),
             test_tasks.noop_task_async,
         )
+
+    def test_pickle_task(self) -> None:
+        pickled_task = pickle.dumps(test_tasks.noop_task)
+        unpickled_task = pickle.loads(pickled_task)
+
+        self.assertEqual(unpickled_task, test_tasks.noop_task)
+
+    def test_unpickle_arbitrary_string(self) -> None:
+        kwargs = {"func": "does.not.exist.fake_task"}
+        msg = "Expected 'does.not.exist.fake_task' to point to a Task instance."
+        with self.assertRaisesMessage(ValueError, msg):
+            Task._reconstruct(kwargs)
+
+    def test_unpickle_non_task_object(self) -> None:
+        kwargs = {"func": "builtins.any"}
+        msg = "Expected 'builtins.any' to point to a Task instance."
+        with self.assertRaisesMessage(ValueError, msg):
+            Task._reconstruct(kwargs)
+
+    def test_pickle_task_result(self) -> None:
+        result = test_tasks.noop_task.enqueue()
+        pickled_result = pickle.dumps(result)
+        unpickled_result = pickle.loads(pickled_result)
+
+        self.assertEqual(unpickled_result, result)
 
     @override_settings(TASKS={})
     def test_no_backends(self) -> None:


### PR DESCRIPTION
Fixes #256 