### PR TITLE
Drop support for Django 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        django-version: ["5.2", "6.0"]
-        exclude:
-          - django-version: "6.0"
-            python-version: "3.10"
-          - django-version: "6.0"
-            python-version: "3.11"
+        django-version: ["5.2"]
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 A backport of `django.tasks` - Django's built-in [Tasks framework](https://docs.djangoproject.com/en/stable/topics/tasks/).
 
+`django-tasks` is suitable for Django versions earlier than 6.0. Users of 6.0+ should use `django.tasks` directly instead.
+
 ## Installation
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django",
     "Framework :: Django :: 5.2",
-    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Natural Language :: English",
@@ -36,7 +35,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "Django>=5.2",
+    "Django>=5.2,<6.0",
     "typing_extensions",
     "django-stubs-ext",
 ]


### PR DESCRIPTION
It shouldn't be needed - it's built-in.